### PR TITLE
feat: shell-tools enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ result
 .claude/*
 !.claude/skills
 !.claude/skills/**
-docs/*
+docs*
 .worktrees/
+browser.json

--- a/flake.lock
+++ b/flake.lock
@@ -208,6 +208,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -290,11 +308,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1774438068,
-        "narHash": "sha256-HK37+gAnYXIrd/m3WT5GNkrlXDQtZkDmv98EE9zNMOQ=",
+        "lastModified": 1774469069,
+        "narHash": "sha256-eDhFgg8kNcb5WCbpQT1RLbExDsnAs71z5tLA3zr2sGw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "d88dfeffbea313ae4bf3acc7c2b030c6c96f801e",
+        "rev": "2475fd2f679e2692875c2ba6fc4076af45db1dab",
         "type": "github"
       },
       "original": {
@@ -306,11 +324,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1774438205,
-        "narHash": "sha256-9+EWPARPinr002cDpOlNkqNJ8+JV8k4+vg+DFbOS+KQ=",
+        "lastModified": 1774467735,
+        "narHash": "sha256-C22BiuSwJsHS1Li0jhPAZ2ElGwD62TgiHkN/tIwJ9iw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "74b1c97a79930238506bb718bd3f0726d7740547",
+        "rev": "e469b9f7d6ea40e1c6a152b847a913ba1d400e7f",
         "type": "github"
       },
       "original": {
@@ -394,11 +412,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1774354685,
-        "narHash": "sha256-c3tWpYGTzUzhwgFQti/pakakTbyiBRpChCUJyxxEjbU=",
+        "lastModified": 1774445873,
+        "narHash": "sha256-chWRF3JavLDD9tOI8Av/1LSAkpvk/+BYvNQvTB8Ctyo=",
         "ref": "refs/heads/main",
-        "rev": "bbf6718c4fc55867be0db8946918ce03d3879f64",
-        "revCount": 7053,
+        "rev": "8196711aaa78c8f62e6f720636ef707783685036",
+        "revCount": 7054,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -930,6 +948,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1772674223,
+        "narHash": "sha256-/suKbHSaSmuC9UY7G0VRQ3aO+QKqxAQPQ19wG7QNkF8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "66d9241e3dc2296726dc522e62dbfe89c7b449f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -1010,11 +1044,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1774434643,
-        "narHash": "sha256-edeFYI5rX7QzcMq0YJrN0bRmFfO3wtbEPCWSo5OoYxI=",
+        "lastModified": 1774466305,
+        "narHash": "sha256-ulF8pWIQ2NQTtoYELLs34a8Ay6+i9/jOqHCQc3r6DJE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "30605f18ab48709b23d05bf159472cc5c6d56371",
+        "rev": "d5709b7e032584d660a261d63b59e18afbf6630c",
         "type": "github"
       },
       "original": {
@@ -1065,7 +1099,8 @@
         "nixpkgs": "nixpkgs_3",
         "nixvim": "nixvim",
         "nur": "nur",
-        "secrets": "secrets"
+        "secrets": "secrets",
+        "ytm-player": "ytm-player"
       }
     },
     "scss-reset": {
@@ -1146,6 +1181,21 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "xdph": {
       "inputs": {
         "hyprland-protocols": [
@@ -1184,6 +1234,25 @@
       "original": {
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
+        "type": "github"
+      }
+    },
+    "ytm-player": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1773719369,
+        "narHash": "sha256-7Ic3xuvufWXHyQk5H7MVpFdFQ1fKdtKGu0PkWSxzmjA=",
+        "owner": "peternaame-boop",
+        "repo": "ytm-player",
+        "rev": "f003966970d651a80e9a7d509749ed15627e5292",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peternaame-boop",
+        "repo": "ytm-player",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
       inputs.home-manager.follows = "home-manager";
     };
     # Other
+    ytm-player.url = "github:peternaame-boop/ytm-player";
   };
 
   outputs = { self, ... }@inputs:

--- a/home/config/.claude/hooks/protect-settings.sh
+++ b/home/config/.claude/hooks/protect-settings.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Block writes to Nix-managed settings.json and redirect to source of truth
+input=$(cat)
+file=$(echo "$input" | jq -r '.file_path // .old_file_path // ""' 2>/dev/null)
+if [[ "$file" == *"/.claude/settings.json" ]]; then
+  echo "settings.json is managed by Nix." >&2
+  echo "Propose a change to home/shared/modules/ai/claude/default.nix instead." >&2
+  exit 2
+fi

--- a/home/config/.config/hypr/hyprland.conf
+++ b/home/config/.config/hypr/hyprland.conf
@@ -196,7 +196,7 @@ bind = $mainMod SHIFT, down, layoutmsg, colresize -conf # narrow column (cycles 
 
 # Screenshot
 bind = , Print, exec, grim -g "$(slurp)" - | wl-copy
-bind = SHIFT, Print, exec, grim -g "$(slurp)"
+bind = SHIFT, Print, exec, mkdir -p ~/Pictures && grim -g "$(slurp)" ~/Pictures/$(date +%Y%m%d_%H%M%S).png
 
 # Functional keybinds
 bind =,XF86AudioMicMute,exec,pamixer --default-source -t

--- a/home/config/.config/lf/scripts/clear
+++ b/home/config/.config/lf/scripts/clear
@@ -1,2 +1,2 @@
 #!/bin/sh
-declare -p -A cmd=([action]=remove [identifier]="preview") > "$FIFO_UEBERZUG"
+printf '{"action":"remove","identifier":"preview"}\n' > "$FIFO_UEBERZUG"

--- a/home/config/.config/lf/scripts/draw
+++ b/home/config/.config/lf/scripts/draw
@@ -1,4 +1,3 @@
 #!/bin/sh
-declare -p -A cmd=([action]=add [identifier]="preview" \
-    [x]="$2" [y]="$3" [max_width]="$4" [max_height]="$5" \
-    [path]="$1") > "$FIFO_UEBERZUG"
+printf '{"action":"add","identifier":"preview","path":"%s","x":%s,"y":%s,"max_width":%s,"max_height":%s}\n' \
+    "$1" "$2" "$3" "$4" "$5" > "$FIFO_UEBERZUG"

--- a/home/config/.config/lf/scripts/lfrun
+++ b/home/config/.config/lf/scripts/lfrun
@@ -8,6 +8,6 @@ function cleanup {
 
 mkfifo "$FIFO_UEBERZUG"
 trap cleanup EXIT
-tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser bash &
+ueberzugpp layer --silent --parser json < "$FIFO_UEBERZUG" &
 
 lf $@

--- a/home/droid/modules/lf.nix
+++ b/home/droid/modules/lf.nix
@@ -5,7 +5,6 @@ let
   additionalPkgs = with pkgs;
     [
       vimv # Batch rename files with vim
-      ueberzug
     ];
 in
 {

--- a/home/shared/modules/ai/claude/default.nix
+++ b/home/shared/modules/ai/claude/default.nix
@@ -3,19 +3,97 @@
 with lib;
 let
   cfg = config.nyx.modules.ai.claude;
+
+  defaultSettings = {
+    statusLine = {
+      type = "command";
+      command = "bunx -y ccstatusline@latest";
+      padding = 0;
+    };
+    enabledPlugins = {
+      "clangd-lsp@claude-plugins-official" = true;
+      "superpowers@claude-plugins-official" = true;
+      "code-review@claude-plugins-official" = true;
+      "playwright@claude-plugins-official" = true;
+      "security-guidance@claude-plugins-official" = true;
+      "claude-md-management@claude-plugins-official" = true;
+      "claude-code-setup@claude-plugins-official" = true;
+      "agent-sdk-dev@claude-plugins-official" = true;
+      "skill-creator@claude-plugins-official" = true;
+      "discord@claude-plugins-official" = true;
+    };
+    skipDangerousModePermissionPrompt = true;
+    hooks = {
+      PreToolUse = [
+        {
+          "_tag" = "ccstatusline-managed";
+          matcher = "Skill";
+          hooks = [
+            {
+              type = "command";
+              command = "bunx -y ccstatusline@latest --hook";
+            }
+          ];
+        }
+        {
+          matcher = "Write|Edit";
+          hooks = [
+            {
+              type = "command";
+              command = "~/.claude/hooks/protect-settings.sh";
+            }
+          ];
+        }
+      ];
+      UserPromptSubmit = [
+        {
+          "_tag" = "ccstatusline-managed";
+          hooks = [
+            {
+              type = "command";
+              command = "bunx -y ccstatusline@latest --hook";
+            }
+          ];
+        }
+      ];
+    };
+  };
 in
 {
   options.nyx.modules.ai.claude = {
     enable = mkEnableOption "Claude Code";
+
     package = mkOption {
       type = types.nullOr types.package;
       default = pkgs.claude-code;
-      description = "The claude-code package to install. Set to null to manage via AUR or system package manager.";
+      description = "The claude-code package. Set to null to manage via AUR or system package manager.";
+    };
+
+    bunPackage = mkOption {
+      type = types.nullOr types.package;
+      default = pkgs.bun;
+      description = "Bun runtime for ccstatusline. Set to null if managing bun via system package manager.";
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = defaultSettings;
+      description = "Contents of ~/.claude/settings.json. Shallow-merged with defaults on top-level keys.";
     };
   };
 
   config = mkIf cfg.enable {
-    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.packages =
+      optional (cfg.package != null) cfg.package
+      ++ optional (cfg.bunPackage != null) cfg.bunPackage
+      ++ [ pkgs.jq ];
+
+    home.file.".claude/settings.json".text =
+      builtins.toJSON (lib.recursiveUpdate defaultSettings cfg.settings);
+
+    home.file.".claude/hooks/protect-settings.sh" = {
+      source = ../../../../config/.claude/hooks/protect-settings.sh;
+      executable = true;
+    };
   };
 }
-

--- a/home/shared/modules/desktop/hypr/default.nix
+++ b/home/shared/modules/desktop/hypr/default.nix
@@ -200,6 +200,18 @@ in
       # Ambxst shell config is seeded via home.activation.seedAmbxstConfig (writable copy, not symlink)
     ];
 
+    # Seed wallpapers into ~/Pictures/wallpapers/ as real files so ambxst's
+    # `find` scan works (it doesn't follow Nix store directory symlinks).
+    # Uses -n so user-added wallpapers are preserved and existing files aren't overwritten.
+    home.activation.seedWallpapers = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      $DRY_RUN_CMD mkdir -p "$HOME/Pictures/wallpapers"
+      for f in "${../../../../config/.config/wallpapers}"/*; do
+        [ -f "$f" ] || continue
+        dst="$HOME/Pictures/wallpapers/$(basename "$f")"
+        [ -e "$dst" ] || $DRY_RUN_CMD cp "$f" "$dst"
+      done
+    '';
+
     # Seed ambxst config files as real writable copies (not symlinks) so ambxst
     # can write preset changes. Uses --no-clobber so rebuilds don't overwrite
     # whatever the user last selected.

--- a/home/shared/modules/shell/astroterm/default.nix
+++ b/home/shared/modules/shell/astroterm/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.astroterm;
+in
+{
+  options.nyx.modules.shell.astroterm = {
+    enable = mkEnableOption "astroterm terminal astronomy viewer";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.astroterm ];
+  };
+}

--- a/home/shared/modules/shell/atuin/default.nix
+++ b/home/shared/modules/shell/atuin/default.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.atuin;
+in
+{
+  options.nyx.modules.shell.atuin = {
+    enable = mkEnableOption "atuin shell history with SQLite backend (replaces mcfly)";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.atuin ];
+
+    nyx.modules.shell.bash.initExtra =
+      mkIf config.nyx.modules.shell.bash.enable ''
+        eval "$(atuin init bash)"
+      '';
+
+    nyx.modules.shell.zsh.initExtra =
+      mkIf config.nyx.modules.shell.zsh.enable ''
+        eval "$(atuin init zsh)"
+      '';
+  };
+}

--- a/home/shared/modules/shell/bandwhich/default.nix
+++ b/home/shared/modules/shell/bandwhich/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.bandwhich;
+in
+{
+  options.nyx.modules.shell.bandwhich = {
+    enable = mkEnableOption "bandwhich network bandwidth monitor by process (Linux only)";
+  };
+
+  config = mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+    home.packages = [ pkgs.bandwhich ];
+  };
+}

--- a/home/shared/modules/shell/bottom/default.nix
+++ b/home/shared/modules/shell/bottom/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.bottom;
+in
+{
+  options.nyx.modules.shell.bottom = {
+    enable = mkEnableOption "bottom (btm) Rust system monitor";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.bottom ];
+  };
+}

--- a/home/shared/modules/shell/dysk/default.nix
+++ b/home/shared/modules/shell/dysk/default.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.dysk;
+in
+{
+  options.nyx.modules.shell.dysk = {
+    enable = mkEnableOption "dysk modern df replacement";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.dysk ];
+    nyx.modules.shell.zsh.initExtra =
+      mkIf config.nyx.modules.shell.zsh.enable ''
+        alias df="dysk"
+      '';
+  };
+}

--- a/home/shared/modules/shell/git/default.nix
+++ b/home/shared/modules/shell/git/default.nix
@@ -84,6 +84,14 @@ in
         gpgSign = true''}
       [gpg]
         program = ${cfg.signing.gpgPath}
+      [core]
+        pager = delta
+      [interactive]
+        diffFilter = delta --color-only
+      [delta]
+        navigate = true
+        side-by-side = true
+        line-numbers = true
       '';
   };
 }

--- a/home/shared/modules/shell/lazygit/default.nix
+++ b/home/shared/modules/shell/lazygit/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.lazygit;
+in
+{
+  options.nyx.modules.shell.lazygit = {
+    enable = mkEnableOption "lazygit TUI git client";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.lazygit ];
+  };
+}

--- a/home/shared/modules/shell/lf/default.nix
+++ b/home/shared/modules/shell/lf/default.nix
@@ -1,19 +1,24 @@
+# home/shared/modules/shell/lf/default.nix
 { config, lib, pkgs, ... }:
 
 with lib;
-let
-  cfg = config.nyx.modules.shell.lf;
+let cfg = config.nyx.modules.shell.lf;
 in
 {
   options.nyx.modules.shell.lf = {
-    enable = mkEnableOption "lf configuration";
+    enable = mkEnableOption "lf file manager with ueberzugpp image preview";
+    ueberzugppPackage = mkOption {
+      type = types.nullOr types.package;
+      default = pkgs.ueberzugpp;
+      description = "ueberzugpp package. Set to null to manage via system package manager (Arch).";
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = with pkgs;
-      [
-        lf
-      ];
+      [ lf ]
+      ++ optional (cfg.ueberzugppPackage != null) cfg.ueberzugppPackage;
+
     xdg.configFile."lf" = {
       source = ../../../../config/.config/lf;
       executable = true;

--- a/home/shared/modules/shell/lm-sensors/default.nix
+++ b/home/shared/modules/shell/lm-sensors/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.lmSensors;
+in
+{
+  options.nyx.modules.shell.lmSensors = {
+    enable = mkEnableOption "lm-sensors hardware monitoring CLI (Linux only)";
+  };
+
+  config = mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+    home.packages = [ pkgs.lm_sensors ];
+  };
+}

--- a/home/shared/modules/shell/navi/default.nix
+++ b/home/shared/modules/shell/navi/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.navi;
+in
+{
+  options.nyx.modules.shell.navi = {
+    enable = mkEnableOption "navi interactive cheatsheet tool";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.navi ];
+  };
+}

--- a/home/shared/modules/shell/ncdu/default.nix
+++ b/home/shared/modules/shell/ncdu/default.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.ncdu;
+in
+{
+  options.nyx.modules.shell.ncdu = {
+    enable = mkEnableOption "ncdu interactive disk usage navigator";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.ncdu ];
+    nyx.modules.shell.zsh.initExtra =
+      mkIf config.nyx.modules.shell.zsh.enable ''
+        alias du="ncdu"
+      '';
+  };
+}

--- a/home/shared/modules/shell/nixvim/default.nix
+++ b/home/shared/modules/shell/nixvim/default.nix
@@ -106,6 +106,7 @@ in
         plenary-nvim
         nvim-web-devicons
         telescope-fzf-native-nvim
+        image-nvim
       ];
 
       # ===== Tools Telescope uses under the hood (+ TS toolchain/parsers)
@@ -114,6 +115,7 @@ in
         fd           # file finder
         tree-sitter
         wl-clipboard # system clipboard on Wayland
+        imagemagick
       ] ++ treeSitterGrammars;
 
       # ===== Keymaps: tree + telescope
@@ -160,6 +162,23 @@ in
               expander_expanded  = "",
             },
           },
+        })
+      '' + lib.optionalString pkgs.stdenv.isLinux ''
+        -- image.nvim: inline image rendering via ueberzugpp (Linux only)
+        require("image").setup({
+          backend = "ueberzug",
+          integrations = {
+            markdown = {
+              enabled = true,
+              clear_in_insert_mode = false,
+              download_remote_images = true,
+            },
+          },
+          max_width = 100,
+          max_height = 12,
+          max_height_window_percentage = math.huge,
+          max_width_window_percentage = math.huge,
+          window_overlap_clear_enabled = false,
         })
       '';
     };

--- a/home/shared/modules/shell/nvtop/default.nix
+++ b/home/shared/modules/shell/nvtop/default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.nvtop;
+in
+{
+  options.nyx.modules.shell.nvtop = {
+    enable = mkEnableOption "nvtop GPU monitor (Linux only)";
+  };
+
+  config = mkIf (cfg.enable && pkgs.stdenv.isLinux) {
+    home.packages = [ pkgs.nvtopPackages.full ];
+  };
+}

--- a/home/shared/modules/shell/ytm-player/default.nix
+++ b/home/shared/modules/shell/ytm-player/default.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.nyx.modules.shell.ytmPlayer;
+in
+{
+  options.nyx.modules.shell.ytmPlayer = {
+    enable = mkEnableOption "ytm-player YouTube Music TUI (OAuth, playlist support)";
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = pkgs.ytm-player;
+      description = "ytm-player package. Defaults to ytm-player (base). Use pkgs.ytm-player-full for mpris/discord/lastfm/spotify extras once upstream fixes spotifyscraper build.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = optional (cfg.package != null) cfg.package;
+  };
+}

--- a/nix/overlays/ytm-player/default.nix
+++ b/nix/overlays/ytm-player/default.nix
@@ -1,0 +1,6 @@
+{ inputs, ... }:
+final: prev:
+{
+  ytm-player = inputs.ytm-player.packages.${prev.stdenv.hostPlatform.system}.ytm-player;
+  ytm-player-full = inputs.ytm-player.packages.${prev.stdenv.hostPlatform.system}.ytm-player-full;
+}

--- a/system/arch/hosts/L242731/default.nix
+++ b/system/arch/hosts/L242731/default.nix
@@ -115,10 +115,25 @@
       };
       jq.enable = true;
       k8sTooling.enable = true;
-      lf.enable = true;
+      lf = {
+        enable = true;
+        ueberzugppPackage = null;
+      };
       lorri.enable = false;
-      mcfly.enable = true;
+      mcfly.enable = false;        # replaced by atuin
       fastfetch.enable = true;
+      # New shell tools
+      astroterm.enable = true;
+      atuin.enable = true;
+      bandwhich.enable = true;
+      bottom.enable = true;
+      dysk.enable = true;
+      lazygit.enable = true;
+      lmSensors.enable = true;
+      navi.enable = true;
+      ncdu.enable = true;
+      nvtop.enable = true;
+      ytmPlayer.enable = true;
       nixvim.enable = true;
       networking.enable = true;
       openssl.enable = true;

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -124,10 +124,25 @@
       };
       jq.enable = true;
       k8sTooling.enable = true;
-      lf.enable = true;
+      lf = {
+        enable = true;
+        ueberzugppPackage = null;
+      };
       lorri.enable = false;
-      mcfly.enable = true;
+      mcfly.enable = false;        # replaced by atuin
       fastfetch.enable = true;
+      # New shell tools
+      astroterm.enable = true;
+      atuin.enable = true;
+      bandwhich.enable = true;
+      bottom.enable = true;
+      dysk.enable = true;
+      lazygit.enable = true;
+      lmSensors.enable = true;
+      navi.enable = true;
+      ncdu.enable = true;
+      nvtop.enable = true;
+      ytmPlayer.enable = true;
       nixvim.enable = true;
       networking.enable = true;
       openssl.enable = true;

--- a/system/nixos/hosts/hephaestus/home.nix
+++ b/system/nixos/hosts/hephaestus/home.nix
@@ -93,8 +93,19 @@
         k8sTooling.enable = true;
         lf.enable = true;
         lorri.enable = false;
-        mcfly.enable = true;
+        mcfly.enable = false;
         fastfetch.enable = true;
+        # New shell tools
+        astroterm.enable = true;
+        atuin.enable = true;
+        bandwhich.enable = true;
+        bottom.enable = true;
+        dysk.enable = true;
+        lazygit.enable = true;
+        lmSensors.enable = true;
+        navi.enable = true;
+        ncdu.enable = true;
+        nvtop.enable = true;
         nixvim.enable = true;
         networking.enable = true;
         openssl.enable = true;


### PR DESCRIPTION
New shell modules: dysk (df alias), ncdu (du alias), lm-sensors, nvtop, bandwhich, atuin, lazygit, astroterm, bottom, navi, ytm-player

Updated modules: lf (ueberzugpp image preview), nixvim (image.nvim), git (delta pager), claude (ccstatusline + protect-settings hook)

Desktop: PrintScreen keybindings (clipboard + ~/Pictures save), seed wallpapers to ~/Pictures/wallpapers/ via home.activation, fix stale waybar configFile in hypr module

Hosts enabled: prometheus, L242731, hephaestus