### PR TITLE
feat: add nyx.modules.sdr — SDR support for prometheus (Arch)

### DIFF
--- a/home/shared/modules/sdr/analysis/default.nix
+++ b/home/shared/modules/sdr/analysis/default.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.sdr.analysis;
+in
+{
+  options.nyx.modules.sdr.analysis = {
+    enable = mkEnableOption "SDR signal analysis tools (multimon-ng protocol decoder)";
+  };
+
+  config = mkIf cfg.enable {
+    # inspectrum (Qt5 GUI) is intentionally NOT installed here — it has the NixGL
+    # issue on Arch and is installed via pacman in 02-install-packages.sh when
+    # INSTALL_SDR=y. Disabling this module does not remove inspectrum.
+    home.packages = with pkgs; [ multimon-ng ];
+  };
+}

--- a/home/shared/modules/sdr/default.nix
+++ b/home/shared/modules/sdr/default.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  imports = [
+    ./sdrpp
+    ./gqrx
+    ./rtl433
+    ./readsb
+    ./analysis
+  ];
+}

--- a/home/shared/modules/sdr/gqrx/default.nix
+++ b/home/shared/modules/sdr/gqrx/default.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.sdr.gqrx;
+in
+{
+  options.nyx.modules.sdr.gqrx = {
+    enable = mkEnableOption "GQRX SDR receiver";
+    package = mkOption {
+      description = "Package for GQRX. Set to null on Arch (installed via pacman).";
+      type = with types; nullOr package;
+      default = pkgs.gqrx;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+  };
+}

--- a/home/shared/modules/sdr/readsb/default.nix
+++ b/home/shared/modules/sdr/readsb/default.nix
@@ -10,6 +10,8 @@ in
   };
 
   config = mkIf cfg.enable {
+    # CLI-only install — no systemd service wiring. Run manually or add a
+    # system-level service module if continuous ADS-B decoding is needed later.
     home.packages = with pkgs; [ readsb ];
   };
 }

--- a/home/shared/modules/sdr/readsb/default.nix
+++ b/home/shared/modules/sdr/readsb/default.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.sdr.readsb;
+in
+{
+  options.nyx.modules.sdr.readsb = {
+    enable = mkEnableOption "readsb ADS-B decoder (aircraft tracking)";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [ readsb ];
+  };
+}

--- a/home/shared/modules/sdr/rtl433/default.nix
+++ b/home/shared/modules/sdr/rtl433/default.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.sdr.rtl433;
+in
+{
+  options.nyx.modules.sdr.rtl433 = {
+    enable = mkEnableOption "rtl_433 — decoder for 433 MHz sensor signals (weather, IoT, etc.)";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [ rtl_433 ];
+  };
+}

--- a/home/shared/modules/sdr/sdrpp/default.nix
+++ b/home/shared/modules/sdr/sdrpp/default.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.sdr.sdrpp;
+in
+{
+  options.nyx.modules.sdr.sdrpp = {
+    enable = mkEnableOption "SDR++ wideband radio receiver software";
+    package = mkOption {
+      description = "Package for SDR++. Set to null on Arch (installed via pacman).";
+      type = with types; nullOr package;
+      default = pkgs.sdrpp;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+  };
+}

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -55,6 +55,7 @@ INSTALL_NORDVPN="n"
 INSTALL_PROTONVPN="n"
 INSTALL_TAILSCALE="n"
 INSTALL_WORK_AGENTS="n"
+INSTALL_SDR="n"
 
 if [[ "$SYNC_MODE" == false ]]; then
   echo ""
@@ -83,6 +84,9 @@ if [[ "$SYNC_MODE" == false ]]; then
 
   read -rp "Install work security tools (CrowdStrike, Cisco VPN)? [y/N] " work_input
   INSTALL_WORK_AGENTS="${work_input,,}"
+
+  read -rp "Install SDR packages (SDR++, GQRX, rtl-sdr driver)? [y/N] " sdr_input
+  INSTALL_SDR="${sdr_input,,}"
 
   echo ""
 fi
@@ -428,6 +432,19 @@ fi
 
 info "Enabling services..."
 sudo systemctl enable --now bluetooth 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Step 13 — SDR
+# ---------------------------------------------------------------------------
+
+if [[ "$INSTALL_SDR" == "y" ]]; then
+  info "Installing SDR packages..."
+  sudo pacman -S --needed --noconfirm rtl-sdr sdrpp gqrx inspectrum
+  info "Installing SDR AUR packages..."
+  _SYSPATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+  _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
+  PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm hamradio-menus
+fi
 
 # ---------------------------------------------------------------------------
 # Done

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -439,11 +439,11 @@ sudo systemctl enable --now bluetooth 2>/dev/null || true
 
 if [[ "$INSTALL_SDR" == "y" ]]; then
   info "Installing SDR packages..."
-  sudo pacman -S --needed --noconfirm rtl-sdr sdrpp gqrx inspectrum
+  sudo pacman -S --needed --noconfirm rtl-sdr gqrx inspectrum
   info "Installing SDR AUR packages..."
   _SYSPATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
   _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
-  PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm hamradio-menus
+  PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm sdrpp hamradio-menus
   # rtl-sdr udev rules grant access via the plugdev group — add user if needed
   if groups "$USER" | grep -q plugdev; then
     info "User '$USER' already in plugdev group."

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -444,7 +444,11 @@ if [[ "$INSTALL_SDR" == "y" ]]; then
   _SYSPATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
   _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
   PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm sdrpp hamradio-menus
-  # rtl-sdr udev rules grant access via the plugdev group — add user if needed
+  # rtl-sdr udev rules grant access via the plugdev group — create and add user if needed
+  if ! getent group plugdev &>/dev/null; then
+    info "Creating plugdev group..."
+    sudo groupadd plugdev
+  fi
   if groups "$USER" | grep -q plugdev; then
     info "User '$USER' already in plugdev group."
   else

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -444,6 +444,14 @@ if [[ "$INSTALL_SDR" == "y" ]]; then
   _SYSPATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
   _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
   PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm hamradio-menus
+  # rtl-sdr udev rules grant access via the plugdev group — add user if needed
+  if groups "$USER" | grep -q plugdev; then
+    info "User '$USER' already in plugdev group."
+  else
+    info "Adding '$USER' to plugdev group for RTL-SDR hardware access..."
+    sudo usermod -aG plugdev "$USER"
+    warn "Group change takes effect after logout/login."
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -100,6 +100,13 @@
       node.enable = false;
       python.enable = true;
     };
+    sdr = {
+      sdrpp   = { enable = true; package = null; };
+      gqrx    = { enable = true; package = null; };
+      rtl433.enable  = true;
+      readsb.enable  = true;
+      analysis.enable = true;
+    };
     shell = {
       awscliv2.enable = false;
       azurecli.enable = true;


### PR DESCRIPTION
## Summary

- Adds new `nyx.modules.sdr` home-manager module category with 5 sub-modules: `sdrpp`, `gqrx`, `rtl433`, `readsb`, `analysis`
- Enables all sub-modules on `prometheus` (Arch) with GUI apps using `package = null` (pacman/NixGL pattern)
- Updates `setup/arch/02-install-packages.sh` with an optional Step 13 that installs `rtl-sdr`, `sdrpp`, `gqrx`, `inspectrum` via pacman and `hamradio-menus` via AUR, plus adds the user to the `plugdev` group for dongle access

## Packages

| Package | Source | Notes |
|---|---|---|
| `rtl-sdr` | pacman | Driver + udev rules + kernel blacklist |
| `sdrpp` | pacman | GUI — NixGL, declared `package = null` in module |
| `gqrx` | pacman | GUI — NixGL, declared `package = null` in module |
| `inspectrum` | pacman | GUI — NixGL, no module option needed |
| `hamradio-menus` | AUR | Desktop menu entries for SDR/ham apps |
| `rtl_433` | nixpkgs | 433 MHz sensor/IoT decoder |
| `readsb` | nixpkgs | ADS-B aircraft tracking (maintained dump1090 fork) |
| `multimon-ng` | nixpkgs | Protocol decoder (POCSAG, APRS, DTMF, etc.) |

## Test plan

- [ ] Run `setup/arch/02-install-packages.sh` on prometheus, answer `y` to SDR prompt
- [ ] Log out and back in (plugdev group takes effect)
- [ ] Run `home-manager switch --flake .#prometheus`
- [ ] Plug in RTL-SDR dongle and launch `sdrpp` or `gqrx`
- [ ] Verify CLI tools are available: `rtl_433 --help`, `readsb --help`, `multimon-ng --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)