### PR TITLE
fix: wezterm clipboard persistence + pywal colors

### DIFF
--- a/home/config/.config/hypr/startup.conf
+++ b/home/config/.config/hypr/startup.conf
@@ -4,6 +4,7 @@ exec=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CU
 exec=systemctl --user restart kanshi
 
 exec-once=dbus-update-activation-environment --all
+exec-once=wl-clip-persist --clipboard regular
 exec-once=hyprpm reload -n
 #exec-once=swww init
 exec-once=gamepad_idle_inhibit >/dev/null 2>&1

--- a/home/config/.config/wal/templates/colors-wezterm.lua
+++ b/home/config/.config/wal/templates/colors-wezterm.lua
@@ -1,0 +1,17 @@
+return {
+  foreground    = "{foreground}",
+  background    = "{background}",
+  cursor_bg     = "{cursor}",
+  cursor_fg     = "{background}",
+  cursor_border = "{cursor}",
+  selection_fg  = "{background}",
+  selection_bg  = "{color15}",
+  ansi = {
+    "{color0}", "{color1}", "{color2}",  "{color3}",
+    "{color4}", "{color5}", "{color6}",  "{color7}",
+  },
+  brights = {
+    "{color8}",  "{color9}",  "{color10}", "{color11}",
+    "{color12}", "{color13}", "{color14}", "{color15}",
+  },
+}

--- a/home/config/.config/wezterm/wezterm.lua
+++ b/home/config/.config/wezterm/wezterm.lua
@@ -7,11 +7,17 @@ end
 
 local font_name = "JetBrainsMonoNL NF"
 
+-- Load pywal colors if available; falls back to WezTerm defaults if not
+local wal_colors = nil
+local wal_path = os.getenv("HOME") .. "/.cache/wal/colors-wezterm.lua"
+local ok, result = pcall(dofile, wal_path)
+if ok then wal_colors = result end
+
 return {
 	-- OpenGL for GPU acceleration, Software for CPU
 	front_end = "OpenGL",
 
-	color_scheme = 'Catppuccin Mocha',
+	colors = wal_colors,
 
 	-- Font config
 	font = font_with_fallback(font_name),

--- a/home/shared/modules/desktop/hypr/default.nix
+++ b/home/shared/modules/desktop/hypr/default.nix
@@ -95,18 +95,21 @@ let
       fi
       rm -f ~/active_paper
       cp "$paper" ~/active_paper
+      wal -i "$paper" -q -n
     fi
   '';
   wallpaper_default = pkgs.writeShellScriptBin "wallpaper_default" ''
     #!/usr/bin/env bash
+    paper=~/.config/wallpapers/liquid1.jpg
     if command -v swww >/dev/null 2>&1; then
       if ! swww query >/dev/null 2>&1; then
         swww-daemon > /dev/null 2>&1 &
         sleep 1
       fi
-      swww img ~/.config/wallpapers/liquid1.jpg --transition-type simple
+      swww img "$paper" --transition-type simple
       rm -f ~/active_paper
-      cp ~/.config/wallpapers/liquid1.jpg ~/active_paper
+      cp "$paper" ~/active_paper
+      wal -i "$paper" -q -n
     fi
   '';
 in
@@ -180,6 +183,7 @@ in
     home.file.".config/wal/templates/cava".source = ../../../../config/.config/wal/templates/cava;
     home.file.".config/wal/templates/colors-hyprland".source = ../../../../config/.config/wal/templates/colors-hyprland;
     home.file.".config/wal/templates/colors-kitty".source = ../../../../config/.config/wal/templates/colors-kitty;
+    home.file.".config/wal/templates/colors-wezterm.lua".source = ../../../../config/.config/wal/templates/colors-wezterm.lua;
     home.file.".config/wal/templates/dunstrc".source = ../../../../config/.config/wal/templates/dunstrc;
     #wallpapers directory
     xdg.configFile = lib.mkMerge [

--- a/home/shared/modules/desktop/hypr/default.nix
+++ b/home/shared/modules/desktop/hypr/default.nix
@@ -96,6 +96,7 @@ let
       rm -f ~/active_paper
       cp "$paper" ~/active_paper
       wal -i "$paper" -q -n
+      touch ~/.config/wezterm/wezterm.lua
     fi
   '';
   wallpaper_default = pkgs.writeShellScriptBin "wallpaper_default" ''
@@ -110,6 +111,7 @@ let
       rm -f ~/active_paper
       cp "$paper" ~/active_paper
       wal -i "$paper" -q -n
+      touch ~/.config/wezterm/wezterm.lua
     fi
   '';
 in

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -22,6 +22,7 @@
       tuxmux
       wget
       vim
+      wl-clip-persist
     ];
   };
 


### PR DESCRIPTION
## Summary

- Adds `wl-clip-persist` to Hyprland startup — keeps Wayland clipboard alive when apps lose focus or close (the standard fix for clipboard issues on Hyprland)
- Adds `wl-clip-persist` package to prometheus via nixpkgs
- Adds pywal template `colors-wezterm.lua` that generates a WezTerm color table from your wallpaper palette (matches the existing kitty/hyprland template pattern)
- Modifies `wezterm.lua` to load pywal colors from `~/.cache/wal/colors-wezterm.lua`, removing the hardcoded Catppuccin Mocha scheme; falls back gracefully to WezTerm defaults if pywal hasn't run yet

## Test plan

- [ ] Run `home-manager switch --flake .#prometheus`
- [ ] Log out and back in (or `hyprctl reload`) to pick up the new startup entry
- [ ] Verify `wl-clip-persist` is running: `pgrep wl-clip-persist`
- [ ] Test clipboard: copy text in WezTerm with `Ctrl+Shift+C`, switch focus to another app, paste
- [ ] Run `wal -i ~/path/to/wallpaper` to regenerate colors — WezTerm should update its theme on next launch (or reload config with `Ctrl+Shift+R`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)