### PR TITLE
feat: ccstatusline config + Arch fixes (#120)

### DIFF
--- a/home/config/.config/ccstatusline/settings.json
+++ b/home/config/.config/ccstatusline/settings.json
@@ -45,6 +45,10 @@
         "type": "session-cost"
       },
       {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
+      },
+      {
         "id": "f743c020-912f-4e9b-a33a-2cd90220f27a",
         "type": "session-usage"
       },
@@ -55,6 +59,10 @@
       {
         "id": "fab3ada5-3487-41e9-8b15-be158e4642bc",
         "type": "block-timer"
+      },
+      {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
       },
       {
         "id": "81720b51-49f0-4de1-8960-6f4a20b7a604",
@@ -69,8 +77,16 @@
         "type": "weekly-usage"
       },
       {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
+      },
+      {
         "id": "7ee5f973-dcd6-4147-a33c-a85cdaccb9dd",
         "type": "weekly-reset-timer"
+      },
+      {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
       },
       {
         "id": "9409349d-821e-405d-818c-21e178795982",
@@ -91,12 +107,24 @@
         "type": "git-branch"
       },
       {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
+      },
+      {
         "id": "4da3e8c6-253a-4a89-816a-b0176f614138",
         "type": "git-changes"
       },
       {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
+      },
+      {
         "id": "6eb565b0-a750-4301-b351-9d9132b950a7",
         "type": "git-insertions"
+      },
+      {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
       },
       {
         "id": "cc130641-608c-4299-a570-07b643f23548",

--- a/home/config/.config/ccstatusline/settings.json
+++ b/home/config/.config/ccstatusline/settings.json
@@ -1,0 +1,124 @@
+{
+  "version": 3,
+  "lines": [
+    [
+      {
+        "id": "bbde285e-e080-4dc5-9b4f-91261004f3b3",
+        "type": "tokens-cached"
+      },
+      {
+        "id": "df6bc6af-adfd-4bb4-852f-4357489c20f9",
+        "type": "separator"
+      },
+      {
+        "id": "4bdde6af-9842-4825-828e-d19e05674aba",
+        "type": "tokens-total"
+      },
+      {
+        "id": "7722e0ff-7c11-476e-a42c-ca6905cff1d0",
+        "type": "separator"
+      },
+      {
+        "id": "78f3348b-21aa-4d8c-9ff3-3ea6dd192c53",
+        "type": "model"
+      },
+      {
+        "id": "677bda6f-cedd-4b96-95a9-404cb5d992f2",
+        "type": "separator"
+      },
+      {
+        "id": "910632f2-bcaf-4a11-807c-38e5a8400021",
+        "type": "context-bar"
+      },
+      {
+        "id": "e94d361d-06c0-4cac-baa6-3176bf5201c2",
+        "type": "separator"
+      },
+      {
+        "id": "be7fe999-f048-4cde-88eb-77716da75f2b",
+        "type": "skills"
+      }
+    ],
+    [
+      {
+        "id": "a38ddc5d-96d3-49f1-81b1-3cbf1a79281a",
+        "type": "session-cost"
+      },
+      {
+        "id": "f743c020-912f-4e9b-a33a-2cd90220f27a",
+        "type": "session-usage"
+      },
+      {
+        "id": "fa10d12e-2a5b-42ed-8358-31dc2536f0a4",
+        "type": "separator"
+      },
+      {
+        "id": "fab3ada5-3487-41e9-8b15-be158e4642bc",
+        "type": "block-timer"
+      },
+      {
+        "id": "81720b51-49f0-4de1-8960-6f4a20b7a604",
+        "type": "reset-timer"
+      },
+      {
+        "id": "83f9cad5-8f1a-4ac5-8b0f-a07272ea7c08",
+        "type": "separator"
+      },
+      {
+        "id": "3e48e82f-a4ea-45b5-82a4-01e9c253bb02",
+        "type": "weekly-usage"
+      },
+      {
+        "id": "7ee5f973-dcd6-4147-a33c-a85cdaccb9dd",
+        "type": "weekly-reset-timer"
+      },
+      {
+        "id": "9409349d-821e-405d-818c-21e178795982",
+        "type": "separator"
+      }
+    ],
+    [
+      {
+        "id": "47cbe50d-563b-4d1a-b453-c475de99bd1f",
+        "type": "current-working-dir"
+      },
+      {
+        "id": "d54f1c41-4054-4544-813f-fd181ce971f5",
+        "type": "separator"
+      },
+      {
+        "id": "56a5162d-caed-4782-a493-f6536a51ff4c",
+        "type": "git-branch"
+      },
+      {
+        "id": "4da3e8c6-253a-4a89-816a-b0176f614138",
+        "type": "git-changes"
+      },
+      {
+        "id": "6eb565b0-a750-4301-b351-9d9132b950a7",
+        "type": "git-insertions"
+      },
+      {
+        "id": "cc130641-608c-4299-a570-07b643f23548",
+        "type": "git-deletions"
+      }
+    ]
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 2,
+  "inheritSeparatorColors": false,
+  "globalBold": false,
+  "powerline": {
+    "enabled": false,
+    "separators": [
+      ""
+    ],
+    "separatorInvertBackground": [
+      false
+    ],
+    "startCaps": [],
+    "endCaps": [],
+    "autoAlign": false
+  }
+}

--- a/home/config/.config/hypr/hyprland.conf
+++ b/home/config/.config/hypr/hyprland.conf
@@ -166,8 +166,11 @@ bind = $mainMod, M, exec, google-chrome-stable --profile-directory=Default --app
 bind = $mainMod, C, exec, code #vs code
 bind = $mainMod, N, exec, obsidian #notes
 bind = $mainMod, V, exec, cava_toggle
-bind = $mainMod, D, exec, show_desktop
-bind = $mainMod, Y, exec, kitty --class="kitty-ytm" ytm
+bind = $mainMod, D, exec, discord
+bind = $mainMod, Y, exec, wezterm start --class kitty-ytm -- ytm
+bind = $mainMod SHIFT, B, exec, firefox
+bind = $mainMod SHIFT, S, exec, show_desktop
+bind = $mainMod SHIFT, Y, exec, pear-desktop
 
 # Ambxst shell
 bind = $mainMod, SPACE, exec, ambxst run launcher

--- a/home/config/.config/wezterm/wezterm.lua
+++ b/home/config/.config/wezterm/wezterm.lua
@@ -142,7 +142,12 @@ return {
 		{
 			key = "v",
 			mods = "CTRL|SHIFT",
-			action = wezterm.action({ PasteFrom = "Clipboard" }),
+			action = wezterm.action_callback(function(_, pane)
+				local success, stdout = wezterm.run_child_process({ "/usr/bin/wl-paste", "--no-newline" })
+				if success and stdout and #stdout > 0 then
+					pane:paste(stdout)
+				end
+			end),
 		},
 		-- Ctrl+C copies only if text is selected, otherwise sends interrupt
 		{
@@ -156,11 +161,16 @@ return {
 				end
 			end),
 		},
-		-- Ctrl+V paste
+		-- Ctrl+V paste (uses wl-paste for reliable Wayland clipboard reads)
 		{
 			key = "v",
 			mods = "CTRL",
-			action = wezterm.action({ PasteFrom = "Clipboard" }),
+			action = wezterm.action_callback(function(_, pane)
+				local success, stdout = wezterm.run_child_process({ "/usr/bin/wl-paste", "--no-newline" })
+				if success and stdout and #stdout > 0 then
+					pane:paste(stdout)
+				end
+			end),
 		},
 	},
 

--- a/home/shared/modules/ai/claude/default.nix
+++ b/home/shared/modules/ai/claude/default.nix
@@ -95,5 +95,8 @@ in
       source = ../../../../config/.claude/hooks/protect-settings.sh;
       executable = true;
     };
+
+    home.file.".config/ccstatusline/settings.json".source =
+      ../../../../config/.config/ccstatusline/settings.json;
   };
 }

--- a/home/shared/modules/ai/claude/default.nix
+++ b/home/shared/modules/ai/claude/default.nix
@@ -96,7 +96,9 @@ in
       executable = true;
     };
 
-    home.file.".config/ccstatusline/settings.json".source =
-      ../../../../config/.config/ccstatusline/settings.json;
+    home.file.".config/ccstatusline/settings.json" = {
+      source = ../../../../config/.config/ccstatusline/settings.json;
+      force = true;
+    };
   };
 }

--- a/home/shared/modules/desktop/hypr/default.nix
+++ b/home/shared/modules/desktop/hypr/default.nix
@@ -233,6 +233,20 @@ in
       done
     '';
 
+    # Seed ~/.cache/ambxst/wallpapers.json with the correct wallPath on first run.
+    # Only creates the file if it doesn't exist, so user changes are preserved.
+    # The path must be absolute (QML doesn't expand ~ or $HOME when passed to find).
+    home.activation.seedAmbxstWallpapersJson = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      _ambxstCache="$HOME/.cache/ambxst"
+      _wallpapersJson="$_ambxstCache/wallpapers.json"
+      if [ ! -f "$_wallpapersJson" ]; then
+        $DRY_RUN_CMD mkdir -p "$_ambxstCache"
+        if [ -z "$DRY_RUN_CMD" ]; then
+          printf '{\n    "activeColorPreset": "",\n    "currentWall": "",\n    "matugenScheme": "scheme-tonal-spot",\n    "perScreenWallpapers": {},\n    "tintEnabled": false,\n    "wallPath": "%s/Pictures/wallpapers"\n}\n' "$HOME" > "$_wallpapersJson"
+        fi
+      fi
+    '';
+
     # Seed the wal color cache from the template so Hyprland's
     # `source=~/.cache/wal/colors-hyprland` doesn't fail on first boot
     # (init_colors runs exec-once which is too late — source= is parsed at startup).

--- a/system/arch/hosts/L242731/default.nix
+++ b/system/arch/hosts/L242731/default.nix
@@ -21,6 +21,8 @@
       tuxmux
       wget
       vim
+      yubikey-manager
+      libfido2
     ];
   };
 
@@ -133,7 +135,7 @@
       navi.enable = true;
       ncdu.enable = true;
       nvtop.enable = true;
-      ytmPlayer.enable = true;
+      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
       nixvim.enable = true;
       networking.enable = true;
       openssl.enable = true;

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -23,6 +23,7 @@
       wget
       vim
       wl-clip-persist
+      yubikey-manager
     ];
   };
 
@@ -150,7 +151,7 @@
       navi.enable = true;
       ncdu.enable = true;
       nvtop.enable = true;
-      ytmPlayer.enable = true;
+      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
       nixvim.enable = true;
       networking.enable = true;
       openssl.enable = true;


### PR DESCRIPTION
## Summary

- Add `~/.config/ccstatusline/settings.json` to Nix via claude module — status bar layout now consistent across machines
- `libfido2` added to L242731 packages
- `ytmPlayer`: set `package = null` on L242731 + prometheus — use pacman version which has `python-dbus-next` MPRIS support, fixing playerctl media keys
- wezterm: use `wl-paste` directly for reliable Wayland clipboard reads
- hypr: seed `ambxst/wallpapers.json` on first run

## Test plan

- [ ] Rebuild L242731 and prometheus — confirm ccstatusline shows correct layout
- [ ] Confirm `playerctl play-pause` works when ytm is running
- [ ] Confirm `libfido2` available (`nix-locate` or `ldconfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)