### PR TITLE
feat: hypr keybinds + arch host config updates

### DIFF
--- a/home/config/.config/hypr/hyprland.conf
+++ b/home/config/.config/hypr/hyprland.conf
@@ -83,6 +83,7 @@ bind = ctrl, left, layoutmsg, focus l
 bind = ctrl, right, layoutmsg, focus r
 # Move columns
 bind = $mainMod, left, layoutmsg, move -col
+bind = $mainMod, right, layoutmsg, move +col
 bind = $mainMod SHIFT, right, layoutmsg, move +col
 # Swap column with neighbor
 bind = $mainMod, comma, layoutmsg, swapcol l
@@ -91,6 +92,10 @@ bind = $mainMod, period, layoutmsg, swapcol r
 # Resize column width (cycles through explicit_column_widths)
 bind = $mainMod, minus, layoutmsg, colresize -conf
 bind = $mainMod, equal, layoutmsg, colresize +conf
+
+# Cycle window height (cycles through explicit_row_heights)
+bind = $mainMod, up, layoutmsg, cycleheight +1
+bind = $mainMod, down, layoutmsg, cycleheight -1
 
 # Dwindle keys (disable for scroller)
 

--- a/system/arch/hosts/L242731/default.nix
+++ b/system/arch/hosts/L242731/default.nix
@@ -28,7 +28,10 @@
 
   nyx.modules = {
     desktop = {
-      cava.enable = true;
+      cava = {
+        enable = true;
+        package = null; # installed via pacman
+      };
       gtk.enable = true;
       kanshi.enable = true;
       hypr = {
@@ -43,9 +46,10 @@
       };
     };
     ai = {
-      chatgpt.enable = false;
+      chatgpt.enable = true;
       gemini.enable = true;
       claude = { enable = true; package = null; };
+      ollama.enable = false
     };
     app = {      
       alacritty = {
@@ -61,7 +65,10 @@
         enable = true;
         package = null;
       };
-      discord.enable = false;
+      discord = {
+        enable = true;
+        package = null; # installed via pacman (discord_arch_electron)
+      };
       firefox.enable = true;
       obs = {
         enable = true;
@@ -92,6 +99,13 @@
       nix.enable = true;
       node.enable = true;
       python.enable = true;
+    };
+    sdr = {
+      sdrpp   = { enable = true; package = null; };
+      gqrx    = { enable = true; package = null; };
+      rtl433.enable  = true;
+      readsb.enable  = true;
+      analysis.enable = true;
     };
     shell = {
       awscliv2.enable = false;
@@ -124,6 +138,24 @@
       lorri.enable = false;
       mcfly.enable = false;        # replaced by atuin
       fastfetch.enable = true;
+      nvtop.enable = true;
+      ambxstColorBridge.enable = true;
+      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
+      nixvim.enable = true;
+      networking.enable = true;
+      openssl.enable = true;
+      ranger.enable = true;
+      starship.enable = true;
+      terraform.enable = true;
+      tmux.enable = true;
+      wal.enable = true;
+      usbutils.enable = true;
+      xdg.enable = true;
+      yq.enable = true;
+      zellij.enable = true;
+      zoxide.enable = true;
+      zsh.enable = true;
+
       # New shell tools
       astroterm.enable = true;
       atuin.enable = true;
@@ -134,21 +166,6 @@
       lmSensors.enable = true;
       navi.enable = true;
       ncdu.enable = true;
-      nvtop.enable = true;
-      ambxstColorBridge.enable = true;
-      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
-      nixvim.enable = true;
-      networking.enable = true;
-      openssl.enable = true;
-      starship.enable = true;
-      terraform.enable = true;
-      tmux.enable = true;
-      wal.enable = true;
-      usbutils.enable = true;
-      xdg.enable = true;
-      yq.enable = true;
-      zellij.enable = true;
-      zsh.enable = true;
     };
   };
 

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -34,6 +34,7 @@
         enable = true;
         package = null; # installed via pacman
       };
+      gtk.enable = true;
       kanshi.enable = true;
       hypr = {
         enable = true;
@@ -46,9 +47,8 @@
         package = inputs.kmonad.packages.${pkgs.stdenv.hostPlatform.system}.default;
       };
     };
-    # Note gaming stuff is installed via arch packages because of NixGL
     ai = {
-      chatgpt.enable = false;
+      chatgpt.enable = true;
       gemini.enable = true;
       claude = { enable = true; package = null; };
       ollama.enable = true;
@@ -99,7 +99,7 @@
       dhall.enable = true;
       lua.enable = true;
       nix.enable = true;
-      node.enable = false;
+      node.enable = true;
       python.enable = true;
     };
     sdr = {
@@ -140,6 +140,23 @@
       lorri.enable = false;
       mcfly.enable = false;        # replaced by atuin
       fastfetch.enable = true;
+      nvtop = { enable = true; package = pkgs.nvtopPackages.amd; };
+      ambxstColorBridge.enable = true;
+      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
+      nixvim.enable = true;
+      networking.enable = true;
+      openssl.enable = true;
+      ranger.enable = true;
+      starship.enable = true;
+      terraform.enable = true;
+      tmux.enable = true;
+      wal.enable = true;
+      usbutils.enable = true;
+      xdg.enable = true;
+      yq.enable = true;
+      zellij.enable = true;
+      zoxide.enable = true;
+      zsh.enable = true;
       # New shell tools
       astroterm.enable = true;
       atuin.enable = true;
@@ -150,21 +167,6 @@
       lmSensors.enable = true;
       navi.enable = true;
       ncdu.enable = true;
-      nvtop = { enable = true; package = pkgs.nvtopPackages.amd; };
-      ambxstColorBridge.enable = true;
-      ytmPlayer = { enable = true; package = null; }; # installed via pacman (has python-dbus-next MPRIS support)
-      nixvim.enable = true;
-      networking.enable = true;
-      openssl.enable = true;
-      starship.enable = true;
-      terraform.enable = true;
-      tmux.enable = true;
-      wal.enable = true;
-      usbutils.enable = true;
-      xdg.enable = true;
-      yq.enable = true;
-      zellij.enable = true;
-      zsh.enable = true;
     };
   };
 


### PR DESCRIPTION
- hyprland: add $mainMod+right to move column right
- hyprland: add $mainMod+up/down to cycle window height
- L242731: enable cava/discord/chatgpt/sdr/zoxide/ranger, reorganize shell tools
- prometheus: enable gtk/chatgpt/node/zoxide/ranger, reorganize shell tools