### PR TITLE
fix Nix PATH contamination in yay upgrade

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -16,7 +16,9 @@ elif [[ $userName == "nix-on-droid" ]]; then
 elif [ -f /etc/arch-release ]; then
   sudo pacman -Syu --noconfirm
   if command -v yay &>/dev/null; then
-    yay -Syu --noconfirm
+    _SYSPATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+    _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
+    PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -Syu --noconfirm
   fi
   setup/arch/02-install-packages.sh --sync
   _HM_CMD="home-manager switch --show-trace --flake .#$hostName"


### PR DESCRIPTION
yay -Syu in update.sh was using Nix's cmake/pkg-config, which can't find system libraries like GTK, glib, and atspi. This broke AUR builds of packages like webkit2gtk. Use the same _SYSPATH/_PKGCFG override pattern already used in 02-install-packages.sh.