### PR TITLE
fix: correct hyprland lua config errors

### DIFF
--- a/home/config/.config/hypr/binds.lua
+++ b/home/config/.config/hypr/binds.lua
@@ -1,4 +1,4 @@
-local main_mod = "SUPER_CTRL_ALT"
+local main_mod = "SUPER + CTRL + ALT"
 
 hl.bind("CTRL + left", hl.dsp.layout("focus l"))
 hl.bind("CTRL + right", hl.dsp.layout("focus r"))

--- a/home/config/.config/hypr/options.lua
+++ b/home/config/.config/hypr/options.lua
@@ -27,14 +27,6 @@ hl.config({
     column_width = 0.5,
     fullscreen_on_one_column = true,
   },
-  plugin = {
-    hyprtrails = {
-      color = "rgba(ffaa00ff)",
-    },
-    hyprwinwrap = {
-      class = "kitty-bg",
-    },
-  },
 })
 
 hl.curve("ease", { type = "bezier", points = { { 0.4, 0.02 }, { 0.21, 1 } } })

--- a/home/config/.config/hypr/rules.lua
+++ b/home/config/.config/hypr/rules.lua
@@ -30,9 +30,6 @@ hl.window_rule({
   size = "55% 55%",
   center = true,
 })
-hl.window_rule({ match = { class = "^(kitty-bg)$" }, float = true })
-hl.window_rule({ match = { class = "^(kitty-bg)$" }, maximize = true })
-hl.window_rule({ match = { class = "^(kitty-bg)$" }, no_focus = true })
 hl.window_rule({ match = { fullscreen = true }, idle_inhibit = "always" })
 hl.window_rule({ match = { class = "^(obs)$" }, idle_inhibit = "always" })
 hl.window_rule({ match = { class = "^(mpv)$" }, idle_inhibit = "focus" })


### PR DESCRIPTION
Follow-up to #157. Fixes two runtime errors in the migrated Hyprland Lua config.

## Changes
- **`binds.lua`** — `"SUPER_CTRL_ALT"` → `"SUPER + CTRL + ALT"`. The Lua bind API parses underscore-joined modifiers as a single unknown keysym (`failed to parse key string: Unknown keysym`), breaking every keybind.
- **`options.lua` / `rules.lua`** — drop `hyprtrails` and `hyprwinwrap` config. Both plugins were removed from the official `hyprland-plugins` repo in [PR #663](https://github.com/hyprwm/hyprland-plugins/pull/663) as unmaintained and are no longer installable via `hyprpm` on Hyprland 0.55.x. Their config keys raised "unknown config key" errors on startup. Also removed the now-dead `kitty-bg` window rules (these positioned the hyprwinwrap background window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)