### PR TITLE
fix(nixvim): replace deprecated vim.diagnostic.goto_{prev,next}

### DIFF
--- a/home/shared/modules/shell/nixvim/default.nix
+++ b/home/shared/modules/shell/nixvim/default.nix
@@ -218,8 +218,8 @@ in
         { mode = "n"; key = "<leader>rn"; action = "<cmd>lua vim.lsp.buf.rename()<cr>";           options.desc = "Rename symbol"; }
         { mode = "n"; key = "<leader>ca"; action = "<cmd>lua vim.lsp.buf.code_action()<cr>";      options.desc = "Code action"; }
         { mode = "n"; key = "<leader>d";  action = "<cmd>lua vim.diagnostic.open_float()<cr>";    options.desc = "Line diagnostics"; }
-        { mode = "n"; key = "[d";         action = "<cmd>lua vim.diagnostic.goto_prev()<cr>";     options.desc = "Prev diagnostic"; }
-        { mode = "n"; key = "]d";         action = "<cmd>lua vim.diagnostic.goto_next()<cr>";     options.desc = "Next diagnostic"; }
+        { mode = "n"; key = "[d";         action = "<cmd>lua vim.diagnostic.jump({count=-1, float=true})<cr>"; options.desc = "Prev diagnostic"; }
+        { mode = "n"; key = "]d";         action = "<cmd>lua vim.diagnostic.jump({count=1, float=true})<cr>";  options.desc = "Next diagnostic"; }
 
         # Gitsigns
         { mode = "n"; key = "]c";         action = "<cmd>Gitsigns next_hunk<cr>";                options.desc = "Next hunk"; }


### PR DESCRIPTION
## Summary
- Replace deprecated `vim.diagnostic.goto_prev()` / `goto_next()` calls on the `[d` / `]d` keymaps with `vim.diagnostic.jump({count=±1, float=true})` (Neovim 0.11+ API)
- Pass `float=true` to preserve the floating diagnostic preview behavior

## Test plan
- [ ] `home-manager switch --flake .#<host>` rebuilds cleanly
- [ ] Open a file with diagnostics, press `]d` / `[d` — jumps between diagnostics and shows the floating preview
- [ ] No deprecation warning on the bottom status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)