### PR TITLE
fix(ai): claude + codex on PATH for DGX hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
         nix-on-droid = { user = "droid"; };
         default = { user = "droid"; };
       };
-      homeConfigurations = mapAttrs' lib.mkArchConfiguration {
+      homeConfigurations = mapAttrs' lib.mkStandaloneLinuxConfiguration {
         L242731 = {
           user = "mdavis67";
           system = "x86_64-linux";
@@ -119,6 +119,16 @@
         prometheus = {
           user = "mwdavisii";
           system = "x86_64-linux";
+        };
+        castor = {
+          user = "mwdavisii";
+          system = "x86_64-linux";
+          hostsDir = ./system/dgx/hosts;
+        };
+        pollux = {
+          user = "mwdavisii";
+          system = "x86_64-linux";
+          hostsDir = ./system/dgx/hosts;
         };
       };
       darwinConfigurations = mapAttrs' mkNixSystemConfiguration {

--- a/flake.nix
+++ b/flake.nix
@@ -122,12 +122,12 @@
         };
         castor = {
           user = "mwdavisii";
-          system = "x86_64-linux";
+          system = "aarch64-linux";
           hostsDir = ./system/dgx/hosts;
         };
         pollux = {
           user = "mwdavisii";
-          system = "x86_64-linux";
+          system = "aarch64-linux";
           hostsDir = ./system/dgx/hosts;
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -124,11 +124,13 @@
           user = "mwdavisii";
           system = "aarch64-linux";
           hostsDir = ./system/dgx/hosts;
+          enableHyprland = false;
         };
         pollux = {
           user = "mwdavisii";
           system = "aarch64-linux";
           hostsDir = ./system/dgx/hosts;
+          enableHyprland = false;
         };
       };
       darwinConfigurations = mapAttrs' mkNixSystemConfiguration {

--- a/home/shared/modules/ai/codex/default.nix
+++ b/home/shared/modules/ai/codex/default.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.ai.codex;
+in
+{
+  options.nyx.modules.ai.codex = {
+    enable = mkEnableOption "OpenAI Codex CLI (lightweight terminal coding agent)";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = pkgs.codex;
+      description = "The codex package. Set to null to manage via system package manager (e.g. snap or npm on hosts where nixpkgs' codex isn't available).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = optional (cfg.package != null) cfg.package;
+  };
+}

--- a/home/shared/profiles/headless.nix
+++ b/home/shared/profiles/headless.nix
@@ -16,6 +16,12 @@
 
   home = {
     stateVersion = "26.05";
+
+    # pipx installs into ~/.local/bin (e.g. HuggingFace CLI `hf` on DGX,
+    # provisioned by setup/dgx/01-install-packages.sh). Adding the path
+    # here avoids touching shell rc files, which home-manager owns.
+    sessionPath = [ "$HOME/.local/bin" ];
+
     packages = with pkgs; [
       rustup
       vhs

--- a/home/shared/profiles/headless.nix
+++ b/home/shared/profiles/headless.nix
@@ -43,7 +43,10 @@
   nyx.modules = {
     ai = {
       launcher.enable = true;
-      claude = { enable = true; package = null; };
+      # Nix-installed on headless (aarch64 wheel available in nixpkgs).
+      # Arch hosts override package=null and pull from pacman/AUR instead.
+      claude.enable = true;
+      codex.enable  = true;
       chatgpt.enable = false;
       gemini.enable  = false;
       ollama.enable  = false;

--- a/home/shared/profiles/headless.nix
+++ b/home/shared/profiles/headless.nix
@@ -1,0 +1,112 @@
+{ config, pkgs, lib, inputs, ... }:
+
+# Shared "headless nyx host" profile.
+#
+# Enables the shell + dev + CLI-AI subset of nyx.modules and nothing else.
+# No desktop / app / sdr modules — those are for GUI hosts. No GPG.
+# nyx.secrets.* is not imported into standalone home-manager (matches
+# prometheus / L242731 behavior).
+#
+# Used by: DGX hosts (castor, pollux).
+
+{
+  programs.home-manager.enable = true;
+  programs.man.enable = true;
+  manual.manpages.enable = true;
+
+  home = {
+    stateVersion = "26.05";
+    packages = with pkgs; [
+      rustup
+      vhs
+      ripgrep
+      fd
+      sd
+      dua
+      just
+      comma
+      nix-index
+      tuxmux
+      wget
+      vim
+      yubikey-manager
+      libfido2
+    ];
+  };
+
+  nyx.modules = {
+    ai = {
+      launcher.enable = true;
+      claude = { enable = true; package = null; };
+      chatgpt.enable = false;
+      gemini.enable  = false;
+      ollama.enable  = false;
+    };
+
+    dev = {
+      cc.enable     = true;
+      rust.enable   = true;
+      go.enable     = true;
+      dhall.enable  = true;
+      lua.enable    = true;
+      nix.enable    = true;
+      node.enable   = true;
+      python.enable = true;
+    };
+
+    shell = {
+      awscliv2.enable     = false;
+      azurecli            = { enable = true; loginBrowser = "firefox"; };
+      bash.enable         = true;
+      bat.enable          = true;
+      direnv.enable       = true;
+      etcd.enable         = true;
+      eza.enable          = true;
+      fastfetch.enable    = true;
+      fzf.enable          = true;
+      gcp.enable          = true;
+      git                 = { enable = true; signing.signByDefault = false; };
+      glow.enable         = true;
+      homelabTools.enable = true;
+      jq.enable           = true;
+      k8sTooling.enable   = true;
+      lazygit.enable      = true;
+      lf                  = { enable = true; ueberzugppPackage = null; };
+      lmSensors.enable    = true;
+      navi.enable         = true;
+      ncdu.enable         = true;
+      networking.enable   = true;
+      nixvim.enable       = true;
+      openssl.enable      = true;
+      ranger.enable       = true;
+      starship.enable     = true;
+      terraform.enable    = true;
+      tmux.enable         = true;
+      usbutils.enable     = true;
+      xdg.enable          = true;
+      yq.enable           = true;
+      zellij.enable       = true;
+      zoxide.enable       = true;
+      zsh.enable          = true;
+
+      # newer tools
+      atuin.enable        = true;
+      bandwhich.enable    = true;
+      bottom.enable       = true;
+      dysk.enable         = true;
+
+      # deliberately off (no display / no value headless)
+      mcfly.enable             = false;
+      lorri.enable             = false;
+      wal.enable               = false;
+      ambxstColorBridge.enable = false;
+      ytmPlayer.enable         = false;
+      weechat.enable           = false;
+      astroterm.enable         = false;
+
+      # deliberately absent: gnupg (GPG dropped entirely for headless hosts)
+    };
+
+    # desktop.*, app.*, sdr.* — intentionally not enabled
+  };
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -101,6 +101,11 @@ rec {
     user,
     system ? "x86_64-linux",
     hostsDir ? ../system/arch/hosts,
+    # Hyprland's home-manager module is only needed on GUI hosts. Pulling
+    # it in on headless boxes (DGX) triggers a submodule fetch of
+    # hyprland-protocols, which fails on an already-shallow-cloned cache
+    # ("shallow roots are not allowed to be updated"). Arch hosts keep it.
+    enableHyprland ? true,
   }:
     let
       pkgs = inputs.self.legacyPackages."${system}";
@@ -113,7 +118,7 @@ rec {
         inherit pkgs;
         modules = [
           inputs.nixvim.homeModules.nixvim
-          (hyprland.homeManagerModules.default)
+        ] ++ (lib.optional enableHyprland hyprland.homeManagerModules.default) ++ [
           (agenix.homeManagerModules.default)
           (import ../home/arch/modules)
           (import userOptions)

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -92,13 +92,21 @@ rec {
       ];
     };
 
-  ################################## ARCH ##################################
-  mkArchConfiguration = name: { config ? name, user, system ? "x86_64-linux" }:
+  ################################## STANDALONE LINUX ##################################
+  # Standalone home-manager builder used by Arch (prometheus, L242731) and
+  # Ubuntu-derived hosts (DGX: castor, pollux). `hostsDir` selects the host
+  # tree; default preserves the historical Arch behavior.
+  mkStandaloneLinuxConfiguration = name: {
+    config ? name,
+    user,
+    system ? "x86_64-linux",
+    hostsDir ? ../system/arch/hosts,
+  }:
     let
       pkgs = inputs.self.legacyPackages."${system}";
       userConf = import (strToFile user ../users);
       homeDirectory = "/home/${userConf.userName}";
-      userOptions = strToPath config ../system/arch/hosts;
+      userOptions = strToPath config hostsDir;
     in
     nameValuePair name (
       inputs.home-manager.lib.homeManagerConfiguration {
@@ -124,6 +132,9 @@ rec {
           { inherit inputs name self system user; };
       }
     );
+
+  # Back-compat alias. Do not remove without auditing call sites.
+  mkArchConfiguration = mkStandaloneLinuxConfiguration;
 
   mkNixSystemConfiguration = name: { config ? name, user ? "nixos", system ? "x86_64-linux", hostname ? "nixos", buildTarget, args ? { }, }:
     nameValuePair name (

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -88,6 +88,9 @@ echo "  - User:      $USER"
 if [[ ! -f "$USER_NIX" ]]; then
   echo "  - New file:  $USER_NIX"
 fi
+if [[ ! -d "system/dgx/hosts/${HOST}" ]]; then
+  echo "  - New file:  system/dgx/hosts/${HOST}/default.nix"
+fi
 echo "  - flake.nix: reduced to a single homeConfigurations entry ($HOST)"
 echo "  - .git:      DELETED (checkout becomes yours, no upstream)"
 echo "  - Then run:  setup/dgx/01-install-packages.sh"

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -51,6 +51,33 @@ if [[ ! -f setup/dgx/01-install-packages.sh || ! -f setup/dgx/02-setup-nix.sh ]]
   error "setup/dgx/01-install-packages.sh or 02-setup-nix.sh missing. Wrong checkout?"
 fi
 
+# ── DGX-only guard ───────────────────────────────────────────────────
+# oneshot.sh only makes sense on an NVIDIA DGX box. The flake.nix
+# rewrite hardcodes system = "aarch64-linux", hostsDir = ./system/dgx/hosts,
+# and enableHyprland = false — none of which apply to an Arch desktop
+# or a random x86_64 Ubuntu VM. Rather than fail confusingly later,
+# refuse up front unless the operator explicitly overrides.
+is_dgx=false
+if [[ -f /etc/dgx-release ]] || grep -qi 'dgx' /etc/os-release 2>/dev/null; then
+  is_dgx=true
+fi
+# Belt: also check for aarch64 + nvidia-smi. Either alone is not enough
+# (a random ARM VM has aarch64; a workstation has nvidia-smi), but the
+# combination together with DGX markers is what we actually need.
+if ! $is_dgx; then
+  echo -e "${RED}[oneshot]${NC} This box does not look like an NVIDIA DGX host."
+  echo "         Checked: /etc/dgx-release (missing) and /etc/os-release (no 'dgx')."
+  echo ""
+  echo "  oneshot.sh is only for DGX boxes (ASUS GB10 / Project DIGITS)."
+  echo "  For other hosts, edit flake.nix by hand and run switch.sh manually."
+  echo ""
+  read -rp "  Override the guard and continue anyway? [y/N] " override
+  if [[ ! "$override" =~ ^[Yy]$ ]]; then
+    error "Aborted (not a DGX host)."
+  fi
+  warn "Continuing on non-DGX host at operator's request. You are on your own."
+fi
+
 # ── Prompts ──────────────────────────────────────────────────────────
 
 info "Setting up nyx for user: $USER"
@@ -81,9 +108,19 @@ else
   info "Reusing existing $USER_NIX."
 fi
 
+# Detect whether we need to rename the system hostname to match $HOST.
+CURRENT_HOST="$(hostname -s 2>/dev/null || hostname)"
+NEEDS_HOSTNAME_CHANGE=false
+if [[ "$CURRENT_HOST" != "$HOST" ]]; then
+  NEEDS_HOSTNAME_CHANGE=true
+fi
+
 echo ""
 info "About to transform this checkout:"
 echo "  - Hostname:  $HOST"
+if $NEEDS_HOSTNAME_CHANGE; then
+  echo "               (system hostname will change from '$CURRENT_HOST' via 'sudo hostnamectl set-hostname')"
+fi
 echo "  - User:      $USER"
 if [[ ! -f "$USER_NIX" ]]; then
   echo "  - New file:  $USER_NIX"
@@ -99,6 +136,26 @@ echo ""
 read -rp "Proceed? [y/N] " confirm
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
   error "Aborted."
+fi
+
+# ── Set system hostname ──────────────────────────────────────────────
+# Done BEFORE the destructive steps below so that if hostnamectl fails
+# (no sudo, no systemd, etc.) we haven't already blown away .git.
+# home-manager doesn't care what the box calls itself — but the peer's
+# vLLM setup + PVE routing DO care, so we align them here.
+
+if $NEEDS_HOSTNAME_CHANGE; then
+  info "Renaming system hostname: $CURRENT_HOST → $HOST"
+  if ! sudo hostnamectl set-hostname "$HOST"; then
+    error "hostnamectl set-hostname failed. Fix manually and re-run."
+  fi
+  # /etc/hosts often has an entry for the old hostname; update it too so
+  # 'sudo' doesn't complain about 'unable to resolve host <old-name>'
+  # on subsequent commands in this same shell.
+  if grep -qE "^127\.0\.1\.1\s+${CURRENT_HOST}\b" /etc/hosts 2>/dev/null; then
+    sudo sed -i.bak -E "s/^(127\.0\.1\.1\s+)${CURRENT_HOST}\b/\1${HOST}/" /etc/hosts
+    info "Updated /etc/hosts (backup at /etc/hosts.bak)"
+  fi
 fi
 
 # ── Write users/<USER>.nix ───────────────────────────────────────────

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# =============================================================================
+# oneshot.sh — turn this checkout into "my nyx" for a single DGX box.
+# =============================================================================
+# For less-technical users who want to fork-in-place:
+#   1. Prompt for hostname (default: current `hostname -s`).
+#   2. Read $USER from the environment.
+#   3. Optionally prompt for display name and email (for git commits later).
+#   4. Write users/$USER.nix if missing.
+#   5. Rewrite flake.nix homeConfigurations to a SINGLE entry (their box).
+#   6. rm -rf .git  (they own this checkout; no upstream contamination).
+#   7. Run setup/dgx/01-install-packages.sh
+#   8. Run setup/dgx/02-setup-nix.sh (with NYX_HOST + NYX_SKIP_CLONE=1)
+#
+# Idempotency: this script is a "make it mine" one-way transform. Once .git
+# is removed it will refuse to run again. That's on purpose — the whole
+# point is that after oneshot.sh, the checkout is theirs.
+#
+# Non-DGX use: works on any Linux box, but 01/02 will complain if it's
+# not a DGX (driver check warns, /models still gets created). Fine for
+# other Ubuntu-derived hosts if you know what you're doing.
+# =============================================================================
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[oneshot]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[oneshot]${NC} $*"; }
+error() { echo -e "${RED}[oneshot]${NC} $*"; exit 1; }
+ask()   { echo -e "${BLUE}[oneshot]${NC} $*"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ── Sanity checks ────────────────────────────────────────────────────
+
+if [[ "${USER:-}" == "" || "${USER:-}" == "root" ]]; then
+  error "\$USER is empty or root. Run this as your regular user (not sudo)."
+fi
+
+if [[ ! -f flake.nix ]]; then
+  error "flake.nix not found. Run this from the root of the nyx checkout."
+fi
+
+if [[ ! -f setup/dgx/01-install-packages.sh || ! -f setup/dgx/02-setup-nix.sh ]]; then
+  error "setup/dgx/01-install-packages.sh or 02-setup-nix.sh missing. Wrong checkout?"
+fi
+
+# ── Prompts ──────────────────────────────────────────────────────────
+
+info "Setting up nyx for user: $USER"
+echo ""
+
+DEFAULT_HOST="$(hostname -s 2>/dev/null || hostname)"
+ask "What should this machine be called?"
+read -rp "    Hostname [$DEFAULT_HOST]: " host_input
+HOST="${host_input:-$DEFAULT_HOST}"
+
+# Validate: nix attrpath must be [a-zA-Z_][a-zA-Z0-9_'-]*
+if ! [[ "$HOST" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*$ ]]; then
+  error "Hostname '$HOST' contains characters that would break flake.nix. Use letters, digits, - and _."
+fi
+
+# Only ask for identity if we're actually going to create a user file.
+USER_NIX="users/${USER}.nix"
+if [[ ! -f "$USER_NIX" ]]; then
+  echo ""
+  ask "Creating $USER_NIX — need a couple of details for git commit metadata."
+  read -rp "    Display name [$USER]: " display_input
+  DISPLAY_NAME="${display_input:-$USER}"
+
+  DEFAULT_EMAIL="${USER}@$(hostname -f 2>/dev/null || echo localhost)"
+  read -rp "    Email [$DEFAULT_EMAIL]: " email_input
+  EMAIL="${email_input:-$DEFAULT_EMAIL}"
+else
+  info "Reusing existing $USER_NIX."
+fi
+
+echo ""
+info "About to transform this checkout:"
+echo "  - Hostname:  $HOST"
+echo "  - User:      $USER"
+if [[ ! -f "$USER_NIX" ]]; then
+  echo "  - New file:  $USER_NIX"
+fi
+echo "  - flake.nix: reduced to a single homeConfigurations entry ($HOST)"
+echo "  - .git:      DELETED (checkout becomes yours, no upstream)"
+echo "  - Then run:  setup/dgx/01-install-packages.sh"
+echo "  - Then run:  setup/dgx/02-setup-nix.sh"
+echo ""
+read -rp "Proceed? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  error "Aborted."
+fi
+
+# ── Write users/<USER>.nix ───────────────────────────────────────────
+
+if [[ ! -f "$USER_NIX" ]]; then
+  info "Writing $USER_NIX"
+  cat > "$USER_NIX" <<EOF
+{
+  userName = "$USER";
+  email = "$EMAIL";
+  displayName = "$DISPLAY_NAME";
+  # Set once you have a signing key: 0xDEADBEEF...
+  signingKey = "";
+  hashedPassword = "";
+  yubiKeySerials = [ ];
+  windowsUserDirName = "";
+}
+EOF
+fi
+
+# ── Rewrite flake.nix ────────────────────────────────────────────────
+#
+# Strategy: replace the entire homeConfigurations = { ... }; block with a
+# single-entry block for this box. Python is used instead of sed because
+# the block spans multiple lines and involves brace matching.
+
+info "Rewriting flake.nix homeConfigurations..."
+python3 - "$HOST" "$USER" <<'PY'
+import re, sys, pathlib
+
+host, user = sys.argv[1], sys.argv[2]
+path = pathlib.Path("flake.nix")
+src = path.read_text()
+
+new_block = f"""      homeConfigurations = mapAttrs' lib.mkStandaloneLinuxConfiguration {{
+        {host} = {{
+          user = "{user}";
+          system = "aarch64-linux";
+          hostsDir = ./system/dgx/hosts;
+          enableHyprland = false;
+        }};
+      }};"""
+
+# The outer homeConfigurations block ends with `      };` at column 6.
+# Inner host entries close with `        };` at column 8. Anchor on the
+# outer close explicitly so nested closes don't stop the match early.
+pattern = re.compile(
+    r"^      homeConfigurations\s*=\s*mapAttrs'\s+lib\.mk\w+\s*\{.*?^      \};",
+    re.DOTALL | re.MULTILINE,
+)
+
+new_src, count = pattern.subn(new_block, src, count=1)
+if count != 1:
+    sys.stderr.write("ERROR: could not find homeConfigurations block in flake.nix\n")
+    sys.exit(1)
+
+path.write_text(new_src)
+PY
+
+# Also drop the DGX host directory placeholder for this hostname if it
+# doesn't exist yet, so flake.nix's hostsDir = ./system/dgx/hosts finds
+# an entry for the new name.
+HOST_DIR="system/dgx/hosts/${HOST}"
+if [[ ! -d "$HOST_DIR" ]]; then
+  info "Creating $HOST_DIR/default.nix"
+  mkdir -p "$HOST_DIR"
+  cat > "$HOST_DIR/default.nix" <<EOF
+{ config, pkgs, lib, inputs, ... }:
+
+# $HOST — headless nyx host. Auto-generated by oneshot.sh.
+# Host-specific overrides go here; nothing needed at first.
+
+{
+  imports = [ ../../../../home/shared/profiles/headless.nix ];
+}
+EOF
+fi
+
+# ── rm -rf .git ──────────────────────────────────────────────────────
+
+if [[ -d .git ]]; then
+  info "Removing .git (this checkout is now yours)"
+  rm -rf .git
+fi
+
+# ── Run 01 and 02 ────────────────────────────────────────────────────
+
+echo ""
+info "Running setup/dgx/01-install-packages.sh"
+bash setup/dgx/01-install-packages.sh
+
+echo ""
+info "Running setup/dgx/02-setup-nix.sh"
+NYX_HOST="$HOST" NYX_SKIP_CLONE=1 NYX_SKIP_BRANCH=1 bash setup/dgx/02-setup-nix.sh
+
+echo ""
+info "Done. Your box '$HOST' is set up."
+info "For ongoing updates: cd $(pwd) && ./switch.sh"

--- a/setup/dgx/01-install-packages.sh
+++ b/setup/dgx/01-install-packages.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Nyx package sync for DGX (Ubuntu-derived) hosts.
+# =============================================================================
+# Installs the minimum set of apt packages nyx assumes are present. Idempotent.
+#
+# Modes:
+#   ./01-install-packages.sh          Interactive — apt update + core + optional prompts
+#   ./01-install-packages.sh --sync   Non-interactive — core packages only, no update
+#                                     (called from switch.sh / update.sh)
+#
+# NEVER touches: nvidia-*, cuda-*, libnvidia-*, docker*, nvidia-container-*,
+# or kernel packages. Those are vendor-managed on DGX OS.
+# =============================================================================
+
+set -euo pipefail
+
+CORE_PKGS=(
+  git curl ca-certificates xz-utils
+  zsh build-essential
+  libfido2-1 unzip
+)
+
+sync_only=false
+if [[ "${1:-}" == "--sync" ]]; then
+  sync_only=true
+fi
+
+if ! $sync_only; then
+  echo "==> apt-get update"
+  sudo apt-get update
+fi
+
+echo "==> Installing/refreshing core packages: ${CORE_PKGS[*]}"
+sudo apt-get install -y --no-install-recommends "${CORE_PKGS[@]}"
+
+if ! $sync_only; then
+  echo ""
+  read -r -p "==> Install optional Yubikey / PC-SC tooling (yubikey-manager, pcscd)? [y/N] " ans
+  if [[ "$ans" =~ ^[Yy]$ ]]; then
+    sudo apt-get install -y --no-install-recommends yubikey-manager pcscd
+    sudo systemctl enable --now pcscd
+    echo "    Yubikey tooling installed and pcscd enabled."
+  fi
+fi
+
+echo ""
+echo "==> Done."

--- a/setup/dgx/01-install-packages.sh
+++ b/setup/dgx/01-install-packages.sh
@@ -2,29 +2,75 @@
 # =============================================================================
 # Nyx package sync for DGX (Ubuntu-derived) hosts.
 # =============================================================================
-# Installs the minimum set of apt packages nyx assumes are present. Idempotent.
+# Installs the minimum set of apt packages nyx assumes are present,
+# validates GB10 hardware assumptions, and prepares the box for the
+# gb10_cluster inference platform. Idempotent.
 #
 # Modes:
 #   ./01-install-packages.sh          Interactive — apt update + core + optional prompts
 #   ./01-install-packages.sh --sync   Non-interactive — core packages only, no update
 #                                     (called from switch.sh / update.sh)
 #
-# NEVER touches: nvidia-*, cuda-*, libnvidia-*, docker*, nvidia-container-*,
-# or kernel packages. Those are vendor-managed on DGX OS.
+# NEVER touches: nvidia-*, cuda-*, libnvidia-*, nvidia-container-*,
+# or kernel packages. Those are vendor-managed on DGX OS. Docker itself
+# is installed via apt if missing (DGX OS ships it; this is a safety net).
 # =============================================================================
 
 set -euo pipefail
 
+# Core apt packages nyx needs before / alongside home-manager.
+# - git curl ca-certificates xz-utils: bootstrap prereqs
+# - zsh build-essential: home-manager login shell + treesitter/native builds
+# - libfido2-1 unzip: yubikey, occasional dev tooling
+# - docker.io docker-buildx docker-compose-v2: gb10_cluster platform prereqs
+#   (idempotent no-op if DGX OS already provides them)
+# - pipx: user-scope Python tool installer (used below for `hf` CLI)
 CORE_PKGS=(
   git curl ca-certificates xz-utils
   zsh build-essential
   libfido2-1 unzip
+  docker.io docker-buildx docker-compose-v2
+  pipx
 )
+
+# GB10 hardware validation. Warnings do not abort; the driver-590 check
+# is a hard error because it corrupts CUDAGraph state on this unified-
+# memory architecture (peer's gb10_cluster finding).
+validate_gb10_hardware() {
+  local arch driver_version runtimes
+
+  arch="$(uname -m)"
+  if [[ "$arch" != "aarch64" ]]; then
+    echo "WARN: uname -m is '$arch'; expected 'aarch64' for GB10. Continuing anyway."
+  fi
+
+  if command -v nvidia-smi &>/dev/null; then
+    driver_version="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)"
+    echo "==> NVIDIA driver: $driver_version"
+    if [[ "$driver_version" == 590.* ]]; then
+      echo "ERROR: NVIDIA driver 590.x has a CUDAGraph deadlock bug on the GB10 UMA architecture."
+      echo "       Downgrade to 580.x before continuing. See gb10_cluster docs."
+      exit 1
+    fi
+  else
+    echo "WARN: nvidia-smi not found. Not on a DGX box, or the driver is broken."
+  fi
+
+  if command -v docker &>/dev/null; then
+    runtimes="$(docker info 2>/dev/null | grep -E '^ Runtimes:' || true)"
+    if ! echo "$runtimes" | grep -q 'nvidia'; then
+      echo "WARN: NVIDIA container runtime not registered with docker. GPU containers will fail."
+      echo "      DGX OS owns nvidia-container-toolkit; fix on the vendor side, not here."
+    fi
+  fi
+}
 
 sync_only=false
 if [[ "${1:-}" == "--sync" ]]; then
   sync_only=true
 fi
+
+validate_gb10_hardware
 
 if ! $sync_only; then
   echo "==> apt-get update"
@@ -33,6 +79,25 @@ fi
 
 echo "==> Installing/refreshing core packages: ${CORE_PKGS[*]}"
 sudo apt-get install -y --no-install-recommends "${CORE_PKGS[@]}"
+
+# ── Model directory ──────────────────────────────────────────────────
+# gb10_cluster compose files mount ${MODEL_DIR:-/models} into the vLLM
+# containers read-only. The dir must exist and be user-writable so
+# `hf download` (below) can populate it without sudo.
+if [[ ! -d /models ]]; then
+  echo "==> Creating /models (owner: $USER)"
+  sudo mkdir -p /models
+  sudo chown "$USER:$USER" /models
+fi
+
+# ── HuggingFace CLI (`hf`) ───────────────────────────────────────────
+# Installed via pipx so it lives under ~/.local/bin. home-manager adds
+# ~/.local/bin to sessionPath (see home/shared/profiles/headless.nix),
+# so no shell rc changes are required.
+if ! command -v hf &>/dev/null && ! [[ -x "$HOME/.local/bin/hf" ]]; then
+  echo "==> Installing HuggingFace CLI via pipx"
+  pipx install "huggingface-hub[hf-xet,cli]"
+fi
 
 if ! $sync_only; then
   echo ""

--- a/setup/dgx/01-install-packages.sh
+++ b/setup/dgx/01-install-packages.sh
@@ -22,14 +22,16 @@ set -euo pipefail
 # - git curl ca-certificates xz-utils: bootstrap prereqs
 # - zsh build-essential: home-manager login shell + treesitter/native builds
 # - libfido2-1 unzip: yubikey, occasional dev tooling
-# - docker.io docker-buildx docker-compose-v2: gb10_cluster platform prereqs
-#   (idempotent no-op if DGX OS already provides them)
 # - pipx: user-scope Python tool installer (used below for `hf` CLI)
+#
+# DELIBERATELY NOT LISTED: docker.io / docker-compose-v2 / docker-buildx.
+# DGX OS ships NVIDIA's own docker stack (containerd.io + docker-ce), and
+# installing Ubuntu's docker.io tries to pull vanilla `containerd`, which
+# conflicts with `containerd.io`. We verify docker is present below instead.
 CORE_PKGS=(
   git curl ca-certificates xz-utils
   zsh build-essential
   libfido2-1 unzip
-  docker.io docker-buildx docker-compose-v2
   pipx
 )
 
@@ -37,7 +39,7 @@ CORE_PKGS=(
 # is a hard error because it corrupts CUDAGraph state on this unified-
 # memory architecture (peer's gb10_cluster finding).
 validate_gb10_hardware() {
-  local arch driver_version runtimes
+  local arch driver_version
 
   arch="$(uname -m)"
   if [[ "$arch" != "aarch64" ]]; then
@@ -56,12 +58,18 @@ validate_gb10_hardware() {
     echo "WARN: nvidia-smi not found. Not on a DGX box, or the driver is broken."
   fi
 
-  if command -v docker &>/dev/null; then
-    runtimes="$(docker info 2>/dev/null | grep -E '^ Runtimes:' || true)"
-    if ! echo "$runtimes" | grep -q 'nvidia'; then
-      echo "WARN: NVIDIA container runtime not registered with docker. GPU containers will fail."
-      echo "      DGX OS owns nvidia-container-toolkit; fix on the vendor side, not here."
-    fi
+  # Docker + NVIDIA runtime are vendor-provided on DGX OS. Verify, don't install.
+  if ! command -v docker &>/dev/null; then
+    echo "WARN: docker not found. DGX OS should ship it — fix on the vendor side."
+    return
+  fi
+
+  # Modern docker info wraps the Runtimes list across multiple lines and
+  # sometimes emits ANSI color; match anywhere in the output rather than
+  # a specific line prefix.
+  if ! docker info 2>/dev/null | grep -q 'nvidia'; then
+    echo "WARN: NVIDIA container runtime not visible in \`docker info\`. GPU containers will fail."
+    echo "      DGX OS owns nvidia-container-toolkit; fix on the vendor side, not here."
   fi
 }
 

--- a/setup/dgx/02-setup-nix.sh
+++ b/setup/dgx/02-setup-nix.sh
@@ -41,21 +41,32 @@ fi
 # Step 2 — Get hostname (must be castor or pollux; prompt if not)
 # ---------------------------------------------------------------------------
 
-DEFAULT_HOST="$(hostname -s 2>/dev/null || hostname)"
-case "$DEFAULT_HOST" in
-  castor|pollux) ;;
-  *)
-    echo "==> Hostname '$DEFAULT_HOST' is not castor or pollux."
-    read -rp "    Enter DGX host to configure [castor]: " host_input
-    DEFAULT_HOST="${host_input:-castor}"
-    ;;
-esac
-HOST="$DEFAULT_HOST"
-echo "==> Using host: $HOST"
+# Two ways to run this step non-interactively (used by oneshot.sh):
+#   NYX_HOST=<name>       - preselects the host, skips the prompt
+#   NYX_SKIP_CLONE=1      - skips the repo clone in Step 5 (already in a checkout)
+#   NYX_SKIP_BRANCH=1     - skips the branch prompt (uses default: main)
+if [[ -n "${NYX_HOST:-}" ]]; then
+  HOST="$NYX_HOST"
+  echo "==> Using host: $HOST (from \$NYX_HOST)"
+else
+  DEFAULT_HOST="$(hostname -s 2>/dev/null || hostname)"
+  case "$DEFAULT_HOST" in
+    castor|pollux) ;;
+    *)
+      echo "==> Hostname '$DEFAULT_HOST' is not castor or pollux."
+      read -rp "    Enter DGX host to configure [castor]: " host_input
+      DEFAULT_HOST="${host_input:-castor}"
+      ;;
+  esac
+  HOST="$DEFAULT_HOST"
+  echo "==> Using host: $HOST"
+fi
 
-read -rp "==> Nyx branch to use [${NYX_BRANCH}]: " branch_input
-NYX_BRANCH="${branch_input:-$NYX_BRANCH}"
-echo "    Using branch: $NYX_BRANCH"
+if [[ -z "${NYX_SKIP_BRANCH:-}" ]]; then
+  read -rp "==> Nyx branch to use [${NYX_BRANCH}]: " branch_input
+  NYX_BRANCH="${branch_input:-$NYX_BRANCH}"
+  echo "    Using branch: $NYX_BRANCH"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 3 — Install Nix (Determinate Systems)
@@ -100,7 +111,12 @@ fi
 # Step 5 — Clone the nyx repo (SSH with HTTPS fallback)
 # ---------------------------------------------------------------------------
 
-if [ ! -d "$NYX_DIR" ]; then
+if [[ -n "${NYX_SKIP_CLONE:-}" ]]; then
+  # Driven by oneshot.sh from inside an existing (possibly de-gitted) checkout.
+  # Use the current working directory as the repo instead of cloning.
+  NYX_DIR="$(pwd)"
+  echo "==> Skipping clone (\$NYX_SKIP_CLONE set); using $NYX_DIR"
+elif [ ! -d "$NYX_DIR" ]; then
   echo ""
   echo "==> Cloning nyx repo ($NYX_BRANCH) to $NYX_DIR..."
   mkdir -p "$(dirname "$NYX_DIR")"

--- a/setup/dgx/02-setup-nix.sh
+++ b/setup/dgx/02-setup-nix.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Nyx bootstrap for DGX (Ubuntu-derived) hosts.
+# =============================================================================
+# Run this after 01-install-packages.sh has installed the core apt packages.
+#
+# Steps:
+#   1. Sanity-check we're on a DGX (has nvidia-smi). Bypass with --force.
+#   2. Install Nix via the Determinate Systems installer.
+#   3. Source the Nix profile.
+#   4. Clone the nyx repo (SSH first, HTTPS fallback).
+#   5. Move collision-prone dotfiles aside so home-manager can take over.
+#   6. Run the first home-manager switch for this host.
+# =============================================================================
+
+set -euo pipefail
+
+NYX_REPO_SSH="git@github.com:mwdavisii/nyx.git"
+NYX_REPO_HTTPS="https://github.com/mwdavisii/nyx.git"
+NYX_DIR="$HOME/code/nyx"
+NYX_BRANCH="main"
+
+force=false
+if [[ "${1:-}" == "--force" ]]; then
+  force=true
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1 — Sanity check: are we on DGX?
+# ---------------------------------------------------------------------------
+
+if ! $force; then
+  if ! command -v nvidia-smi &>/dev/null; then
+    echo "ERROR: nvidia-smi not found. This script targets NVIDIA DGX hosts."
+    echo "       Re-run with --force to override the check."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Get hostname (must be castor or pollux; prompt if not)
+# ---------------------------------------------------------------------------
+
+DEFAULT_HOST="$(hostname -s 2>/dev/null || hostname)"
+case "$DEFAULT_HOST" in
+  castor|pollux) ;;
+  *)
+    echo "==> Hostname '$DEFAULT_HOST' is not castor or pollux."
+    read -rp "    Enter DGX host to configure [castor]: " host_input
+    DEFAULT_HOST="${host_input:-castor}"
+    ;;
+esac
+HOST="$DEFAULT_HOST"
+echo "==> Using host: $HOST"
+
+read -rp "==> Nyx branch to use [${NYX_BRANCH}]: " branch_input
+NYX_BRANCH="${branch_input:-$NYX_BRANCH}"
+echo "    Using branch: $NYX_BRANCH"
+
+# ---------------------------------------------------------------------------
+# Step 3 — Install Nix (Determinate Systems)
+# ---------------------------------------------------------------------------
+
+if ! command -v nix &>/dev/null; then
+  echo ""
+  echo "==> Installing Nix via Determinate Systems installer..."
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+    sh -s -- install linux --no-confirm --init systemd
+else
+  echo "==> Nix already installed: $(nix --version)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Source the Nix profile
+# ---------------------------------------------------------------------------
+
+NIX_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+if [ -f "$NIX_PROFILE" ]; then
+  # shellcheck source=/dev/null
+  . "$NIX_PROFILE"
+  echo "==> Nix profile sourced."
+else
+  echo "WARNING: Nix profile not found at $NIX_PROFILE — you may need to open a new shell."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — Clone the nyx repo (SSH with HTTPS fallback)
+# ---------------------------------------------------------------------------
+
+if [ ! -d "$NYX_DIR" ]; then
+  echo ""
+  echo "==> Cloning nyx repo ($NYX_BRANCH) to $NYX_DIR..."
+  mkdir -p "$(dirname "$NYX_DIR")"
+  if git clone -b "$NYX_BRANCH" "$NYX_REPO_SSH" "$NYX_DIR" 2>/dev/null; then
+    echo "    Cloned via SSH."
+  else
+    echo "    SSH clone failed (keys not set up?). Falling back to HTTPS..."
+    git clone -b "$NYX_BRANCH" "$NYX_REPO_HTTPS" "$NYX_DIR"
+    echo "    Cloned via HTTPS. Switch remote to SSH later:"
+    echo "      cd $NYX_DIR && git remote set-url origin $NYX_REPO_SSH"
+  fi
+else
+  echo "==> Repo already present at $NYX_DIR"
+  git -C "$NYX_DIR" checkout "$NYX_BRANCH"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6 — Move collision-prone dotfiles aside
+# ---------------------------------------------------------------------------
+# Ubuntu useradd creates skeleton dotfiles (.bashrc, .profile, .bash_logout).
+# home-manager refuses to overwrite files it didn't create. Move them into
+# a timestamped backup dir so this script is safe to re-run.
+
+BACKUP_DIR="$HOME/.dotfiles.pre-nyx.$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+moved_any=false
+for f in .bashrc .bash_profile .bash_logout .bash_history .profile .zshrc; do
+  if [ -e "$HOME/$f" ] && [ ! -L "$HOME/$f" ]; then
+    mv "$HOME/$f" "$BACKUP_DIR/"
+    moved_any=true
+  fi
+done
+if $moved_any; then
+  echo "==> Moved collision-prone dotfiles to $BACKUP_DIR"
+else
+  echo "==> No collision-prone dotfiles present; skipping backup."
+  rmdir "$BACKUP_DIR" 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7 — home-manager switch
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "==> Running home-manager switch for host: $HOST"
+cd "$NYX_DIR"
+nix run home-manager -- switch --show-trace -b backup --flake ".#$HOST"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================================"
+echo " Bootstrap complete!"
+echo "================================================================"
+echo ""
+echo " Log out and back in (or run: exec zsh -l) so zsh becomes your"
+echo " login shell and PATH picks up the new environment."
+echo ""
+echo " For ongoing use:"
+echo "   cd $NYX_DIR"
+echo "   ./switch.sh"
+echo "================================================================"

--- a/setup/dgx/02-setup-nix.sh
+++ b/setup/dgx/02-setup-nix.sh
@@ -84,6 +84,19 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Step 4b — Verify flakes are enabled in /etc/nix/nix.conf (idempotent)
+# ---------------------------------------------------------------------------
+# The Determinate Systems installer writes this by default, but future
+# installer versions could drop it. We rely on flakes in Step 7, so guard
+# against a confusing later failure by warning up front.
+
+if ! sudo grep -qE '^experimental-features.*(nix-command|flakes)' /etc/nix/nix.conf 2>/dev/null; then
+  echo "WARNING: 'experimental-features = nix-command flakes' not found in /etc/nix/nix.conf."
+  echo "         The Nix installer should have set this — home-manager switch may fail."
+  echo "         To fix: sudo tee -a /etc/nix/nix.conf <<< 'experimental-features = nix-command flakes'"
+fi
+
+# ---------------------------------------------------------------------------
 # Step 5 — Clone the nyx repo (SSH with HTTPS fallback)
 # ---------------------------------------------------------------------------
 

--- a/setup/dgx/README.md
+++ b/setup/dgx/README.md
@@ -1,0 +1,87 @@
+# DGX (Castor & Pollux) Install Guide
+
+Two-phase setup: **01-install-packages.sh** installs the apt packages nyx assumes are present, **02-setup-nix.sh** bootstraps Nix and home-manager. DGX OS ships pre-installed — there is no Phase 0 disk-partition step (unlike `setup/arch/`).
+
+## Prerequisites
+
+- DGX OS booted, logged in as your user (`mwdavisii`).
+- Sudo access.
+- Network reachable (`ping -c 3 github.com`).
+- Hostname set to `castor` or `pollux` (`sudo hostnamectl set-hostname castor` if not).
+
+## Phase 1 — Vendor state (no-op)
+
+DGX OS is already installed. NVIDIA drivers, CUDA, and (if enabled) `nvidia-container-toolkit` are managed by NVIDIA's apt repos. **Nyx does not touch them.**
+
+Confirm:
+
+```bash
+nvidia-smi
+```
+
+If this doesn't work, fix the vendor install first — nothing in nyx will help.
+
+## Phase 2 — Core apt packages
+
+```bash
+curl -LO https://raw.githubusercontent.com/mwdavisii/nyx/main/setup/dgx/01-install-packages.sh
+chmod +x 01-install-packages.sh
+./01-install-packages.sh
+```
+
+Installs a small core set: `git curl ca-certificates xz-utils zsh build-essential libfido2-1 unzip`.
+
+Optional prompt (interactive mode only):
+
+| Prompt | Notes |
+|---|---|
+| Yubikey / PC-SC tooling | Installs `yubikey-manager` and `pcscd`, enables the service |
+
+This script is idempotent. It also runs automatically in `--sync` mode from `./switch.sh` and `./update.sh` on every rebuild.
+
+## Phase 3 — Nix & home-manager
+
+```bash
+curl -LO https://raw.githubusercontent.com/mwdavisii/nyx/main/setup/dgx/02-setup-nix.sh
+chmod +x 02-setup-nix.sh
+./02-setup-nix.sh
+```
+
+Steps:
+
+1. Sanity check for `nvidia-smi` (bypass with `--force`).
+2. Detect hostname (`castor` / `pollux`), or prompt.
+3. Install Nix via the Determinate Systems installer.
+4. Clone `~/code/nyx` (SSH → HTTPS fallback).
+5. Move collision-prone shell dotfiles to `~/.dotfiles.pre-nyx.<timestamp>/`.
+6. First `home-manager switch --flake .#<hostname>`.
+
+After it finishes, log out and log back in (or run `exec zsh -l`) so zsh becomes your login shell.
+
+## Ongoing use
+
+```bash
+cd ~/code/nyx
+./switch.sh
+```
+
+`switch.sh` detects DGX (via `/etc/dgx-release` or `/etc/os-release` grep), runs `01-install-packages.sh --sync` (no prompts, no `apt-get update`), then `home-manager switch --flake .#<hostname>`.
+
+To also pull system-level apt upgrades:
+
+```bash
+cd ~/code/nyx
+./update.sh
+```
+
+`update.sh` adds `sudo apt-get update && sudo apt-get -y upgrade` before the same sync + switch sequence. It does **not** run `apt-get autoremove` (foot-gun on a vendor-tuned box) and does not run `full-upgrade` / `dist-upgrade`.
+
+## What nyx manages vs. what DGX OS manages
+
+| Layer | Owner |
+|---|---|
+| Kernel, NVIDIA drivers, CUDA, container runtime, `docker*` | DGX OS (NVIDIA apt repos) |
+| Core apt packages listed above | `setup/dgx/01-install-packages.sh` |
+| Shell, dev tooling, editor, CLI AI, home dotfiles | home-manager (this repo) |
+| Anything under `nyx.modules.desktop.*` / `app.*` / `sdr.*` | Not enabled — headless profile |
+| `nyx.secrets.*` (agenix) | Not wired for standalone home-manager |

--- a/setup/dgx/README.md
+++ b/setup/dgx/README.md
@@ -1,6 +1,9 @@
 # DGX (Castor & Pollux) Install Guide
 
-Two-phase setup: **01-install-packages.sh** installs the apt packages nyx assumes are present, **02-setup-nix.sh** bootstraps Nix and home-manager. DGX OS ships pre-installed — there is no Phase 0 disk-partition step (unlike `setup/arch/`).
+Three-phase setup on a pre-installed DGX OS box:
+1. **01-install-packages.sh** — validate GB10 hardware, install apt prereqs (including docker + hf CLI for the `gb10_cluster` platform), ensure `/models` exists.
+2. **02-setup-nix.sh** — bootstrap Nix and run the first `home-manager switch`.
+3. **`gb10_cluster` runbook** (peer's repo) — deploy the vLLM / observability platform.
 
 ## Prerequisites
 
@@ -11,7 +14,7 @@ Two-phase setup: **01-install-packages.sh** installs the apt packages nyx assume
 
 ## Phase 1 — Vendor state (no-op)
 
-DGX OS is already installed. NVIDIA drivers, CUDA, and (if enabled) `nvidia-container-toolkit` are managed by NVIDIA's apt repos. **Nyx does not touch them.**
+DGX OS is already installed. NVIDIA drivers, CUDA, and `nvidia-container-toolkit` are managed by NVIDIA's apt repos. **Nyx does not touch them.**
 
 Confirm:
 
@@ -21,7 +24,9 @@ nvidia-smi
 
 If this doesn't work, fix the vendor install first — nothing in nyx will help.
 
-## Phase 2 — Core apt packages
+**Driver check:** Nyx will hard-fail Phase 2 if `nvidia-smi` reports driver `590.x` — that series has a CUDAGraph deadlock on the GB10 UMA architecture (finding from peer's `gb10_cluster`). Downgrade to `580.x` first.
+
+## Phase 2 — apt prereqs + GB10 validation
 
 ```bash
 curl -LO https://raw.githubusercontent.com/mwdavisii/nyx/main/setup/dgx/01-install-packages.sh
@@ -29,7 +34,14 @@ chmod +x 01-install-packages.sh
 ./01-install-packages.sh
 ```
 
-Installs a small core set: `git curl ca-certificates xz-utils zsh build-essential libfido2-1 unzip`.
+Runs GB10 hardware validation up front (arch, driver, docker nvidia runtime), then installs:
+
+- **Core** (dev/shell prereqs): `git curl ca-certificates xz-utils zsh build-essential libfido2-1 unzip`
+- **`gb10_cluster` platform prereqs**: `docker.io docker-buildx docker-compose-v2 pipx`
+
+Also:
+- Creates `/models` owned by your user (peer's vLLM containers mount it read-only).
+- Installs HuggingFace CLI (`hf`) into `~/.local/bin` via pipx, so peer's `models/download-*.sh` scripts work.
 
 Optional prompt (interactive mode only):
 
@@ -58,6 +70,19 @@ Steps:
 
 After it finishes, log out and log back in (or run `exec zsh -l`) so zsh becomes your login shell.
 
+## Phase 4 — Application platform (`gb10_cluster`)
+
+Nyx does not manage the LLM inference stack. Peer's `gb10_cluster` repo owns the compose files, vLLM configs, LiteLLM routing, model downloads, and observability.
+
+```bash
+cd ~/code
+git clone git@github.com:<peer-org>/gb10_cluster.git   # replace with the actual URL
+cd gb10_cluster
+# Follow docs/RUNBOOK.md from there.
+```
+
+Everything nyx installs in Phase 2 (docker, `hf`, `/models`) is what `gb10_cluster` expects to already be present.
+
 ## Ongoing use
 
 ```bash
@@ -76,12 +101,13 @@ cd ~/code/nyx
 
 `update.sh` adds `sudo apt-get update && sudo apt-get -y upgrade` before the same sync + switch sequence. It does **not** run `apt-get autoremove` (foot-gun on a vendor-tuned box) and does not run `full-upgrade` / `dist-upgrade`.
 
-## What nyx manages vs. what DGX OS manages
+## Ownership boundaries
 
-| Layer | Owner |
+| Concern | Owner |
 |---|---|
-| Kernel, NVIDIA drivers, CUDA, container runtime, `docker*` | DGX OS (NVIDIA apt repos) |
-| Core apt packages listed above | `setup/dgx/01-install-packages.sh` |
-| Shell, dev tooling, editor, CLI AI, home dotfiles | home-manager (this repo) |
+| Kernel, NVIDIA drivers, CUDA, `nvidia-container-toolkit` | DGX OS (NVIDIA apt repos) |
+| Docker daemon, `hf` CLI, `/models` mount target | nyx (`setup/dgx/01-install-packages.sh`) |
+| Shell, dev tooling, editor, CLI AI, home dotfiles | home-manager (this repo, via `headless.nix`) |
+| vLLM containers, LiteLLM, Prometheus/Grafana, model weights | `gb10_cluster` (peer) |
 | Anything under `nyx.modules.desktop.*` / `app.*` / `sdr.*` | Not enabled — headless profile |
 | `nyx.secrets.*` (agenix) | Not wired for standalone home-manager |

--- a/setup/dgx/README.md
+++ b/setup/dgx/README.md
@@ -1,9 +1,9 @@
 # DGX (Castor & Pollux) Install Guide
 
 Three-phase setup on a pre-installed DGX OS box:
-1. **01-install-packages.sh** — validate GB10 hardware, install apt prereqs (including docker + hf CLI for the `gb10_cluster` platform), ensure `/models` exists.
+1. **01-install-packages.sh** — validate GB10 hardware, install apt prereqs (docker + hf CLI), ensure `/models` exists.
 2. **02-setup-nix.sh** — bootstrap Nix and run the first `home-manager switch`.
-3. **`gb10_cluster` runbook** (peer's repo) — deploy the vLLM / observability platform.
+3. **vLLM containers** — run `timothystewart6/vllm-gb10` against your model weights, exposed to the LAN. The control plane (LiteLLM, Langfuse, observability, etc.) lives elsewhere.
 
 ## Prerequisites
 
@@ -37,11 +37,11 @@ chmod +x 01-install-packages.sh
 Runs GB10 hardware validation up front (arch, driver, docker nvidia runtime), then installs:
 
 - **Core** (dev/shell prereqs): `git curl ca-certificates xz-utils zsh build-essential libfido2-1 unzip`
-- **`gb10_cluster` platform prereqs**: `docker.io docker-buildx docker-compose-v2 pipx`
+- **vLLM prereqs**: `docker.io docker-buildx docker-compose-v2 pipx`
 
 Also:
-- Creates `/models` owned by your user (peer's vLLM containers mount it read-only).
-- Installs HuggingFace CLI (`hf`) into `~/.local/bin` via pipx, so peer's `models/download-*.sh` scripts work.
+- Creates `/models` owned by your user (the vLLM container mounts it read-only).
+- Installs HuggingFace CLI (`hf`) into `~/.local/bin` via pipx for downloading model weights.
 
 Optional prompt (interactive mode only):
 
@@ -70,18 +70,51 @@ Steps:
 
 After it finishes, log out and log back in (or run `exec zsh -l`) so zsh becomes your login shell.
 
-## Phase 4 — Application platform (`gb10_cluster`)
+## Phase 4 — vLLM (application layer, out of nyx scope)
 
-Nyx does not manage the LLM inference stack. Peer's `gb10_cluster` repo owns the compose files, vLLM configs, LiteLLM routing, model downloads, and observability.
+Nyx does not manage the inference stack. Everything nyx installs in Phase 2 (docker, `hf`, `/models`) is what a vLLM container needs to already be present.
+
+The image that works on GB10's aarch64 + sm_121 (Blackwell) is `timothystewart6/vllm-gb10:latest` — a known-good combination of vLLM + PyTorch + CUDA + flash-attn compiled for this architecture, courtesy of a peer's work. Reusing that image is what makes vLLM boot on GB10 without rebuilding the entire stack from source.
+
+Download a model:
 
 ```bash
-cd ~/code
-git clone git@github.com:<peer-org>/gb10_cluster.git   # replace with the actual URL
-cd gb10_cluster
-# Follow docs/RUNBOOK.md from there.
+hf download nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
+    --local-dir /models/nemotron-super-120b-a12b-nvfp4
 ```
 
-Everything nyx installs in Phase 2 (docker, `hf`, `/models`) is what `gb10_cluster` expects to already be present.
+Minimal per-host compose file (write once, per box):
+
+```yaml
+# ~/vllm.yml
+services:
+  vllm:
+    image: timothystewart6/vllm-gb10:latest
+    shm_size: '4g'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    volumes:
+      - /models/<model-dir>:/model:ro
+    ports:
+      - "0.0.0.0:8001:8000"
+    command: >-
+      vllm serve /model
+      --served-model-name <name>
+      --enforce-eager --dtype auto --max-model-len 32768
+      --gpu-memory-utilization 0.85
+      --enable-prefix-caching --trust-remote-code
+      --kv-cache-dtype fp8
+    restart: unless-stopped
+```
+
+Run: `docker compose -f ~/vllm.yml up -d`. Point your LAN LiteLLM (running in PVE) at `http://<host>:8001/v1`.
+
+The LiteLLM, Langfuse, Prometheus, Grafana, Caddy, Open WebUI, n8n, and Postgres containers you may have seen in a colleague's `gb10_cluster` repo — those are a self-contained platform stack. **You already run those services elsewhere; skip them.**
 
 ## Ongoing use
 
@@ -108,6 +141,7 @@ cd ~/code/nyx
 | Kernel, NVIDIA drivers, CUDA, `nvidia-container-toolkit` | DGX OS (NVIDIA apt repos) |
 | Docker daemon, `hf` CLI, `/models` mount target | nyx (`setup/dgx/01-install-packages.sh`) |
 | Shell, dev tooling, editor, CLI AI, home dotfiles | home-manager (this repo, via `headless.nix`) |
-| vLLM containers, LiteLLM, Prometheus/Grafana, model weights | `gb10_cluster` (peer) |
+| vLLM container + model weights | You (hand-rolled compose file, see Phase 4) |
+| LiteLLM, Langfuse, Prometheus, Grafana | Already running in your PVE lab |
 | Anything under `nyx.modules.desktop.*` / `app.*` / `sdr.*` | Not enabled — headless profile |
 | `nyx.secrets.*` (agenix) | Not wired for standalone home-manager |

--- a/switch.sh
+++ b/switch.sh
@@ -30,6 +30,9 @@ elif [ -f /etc/arch-release ]; then
   else
     eval "$_HM_CMD"
   fi
+elif [ -f /etc/dgx-release ] || grep -qi 'dgx' /etc/os-release 2>/dev/null; then
+  setup/dgx/01-install-packages.sh --sync
+  home-manager switch --show-trace -b backup --flake .#$hostName
 else
   sudo nixos-rebuild switch --show-trace --flake .#$hostName
 fi

--- a/system/dgx/hosts/castor/default.nix
+++ b/system/dgx/hosts/castor/default.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, lib, inputs, ... }:
+
+# Castor — ASUS DGX box, headless. Nix drivers/CUDA remain vendor-managed.
+# Host-specific overrides go here; nothing needed at first.
+
+{
+  imports = [ ../../../../home/shared/profiles/headless.nix ];
+}

--- a/system/dgx/hosts/pollux/default.nix
+++ b/system/dgx/hosts/pollux/default.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, lib, inputs, ... }:
+
+# Pollux — ASUS DGX box, headless. Nix drivers/CUDA remain vendor-managed.
+# Host-specific overrides go here; nothing needed at first.
+
+{
+  imports = [ ../../../../home/shared/profiles/headless.nix ];
+}

--- a/update.sh
+++ b/update.sh
@@ -27,6 +27,11 @@ elif [ -f /etc/arch-release ]; then
   else
     eval "$_HM_CMD"
   fi
+elif [ -f /etc/dgx-release ] || grep -qi 'dgx' /etc/os-release 2>/dev/null; then
+  sudo apt-get update
+  sudo apt-get -y upgrade
+  setup/dgx/01-install-packages.sh --sync
+  home-manager switch --show-trace --flake .#$hostName
 else
   sudo nixos-rebuild switch --show-trace --flake .#$hostName
 fi


### PR DESCRIPTION
On castor after \`home-manager switch\`, neither \`claude\` nor \`codex\` was on PATH — the ai launcher script exists but points at binaries nyx never installed.

## Root cause

- \`ai.claude\` in the headless profile had \`package = null\`. That's correct on Arch (claude comes from pacman/AUR) but wrong on Ubuntu-side DGX where nothing else provides it.
- There was no \`nyx.modules.ai.codex\` module at all. The launcher references \`codex\` unconditionally.

## Fix

1. New \`home/shared/modules/ai/codex/default.nix\` — wraps \`pkgs.codex\` (nixpkgs 0.142.0, aarch64-available). Same shape as the claude module: a package option that can be null on hosts installing codex elsewhere.
2. \`home/shared/profiles/headless.nix\`: drop \`package = null\` from \`ai.claude\` so nyx installs \`pkgs.claude-code\` (aarch64 build available); enable \`ai.codex\`.

Verified: \`nix eval .#homeConfigurations.castor.activationPackage\` succeeds; \`nix build .#homeConfigurations.prometheus.activationPackage\` still succeeds (Arch host is unaffected — it sets \`package = null\` in its own host default.nix, not via the profile).