### PR TITLE
fix(ai): claude + codex on PATH for DGX hosts

### DIFF
--- a/home/shared/modules/ai/codex/default.nix
+++ b/home/shared/modules/ai/codex/default.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.ai.codex;
+in
+{
+  options.nyx.modules.ai.codex = {
+    enable = mkEnableOption "OpenAI Codex CLI (lightweight terminal coding agent)";
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = pkgs.codex;
+      description = "The codex package. Set to null to manage via system package manager (e.g. snap or npm on hosts where nixpkgs' codex isn't available).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = optional (cfg.package != null) cfg.package;
+  };
+}

--- a/home/shared/profiles/headless.nix
+++ b/home/shared/profiles/headless.nix
@@ -43,7 +43,10 @@
   nyx.modules = {
     ai = {
       launcher.enable = true;
-      claude = { enable = true; package = null; };
+      # Nix-installed on headless (aarch64 wheel available in nixpkgs).
+      # Arch hosts override package=null and pull from pacman/AUR instead.
+      claude.enable = true;
+      codex.enable  = true;
       chatgpt.enable = false;
       gemini.enable  = false;
       ollama.enable  = false;


### PR DESCRIPTION
Supersedes #175 (rebased on top of merged #173+#174).

On castor after \`home-manager switch\`, neither \`claude\` nor \`codex\` was on PATH — the ai launcher script exists but points at binaries nyx never installed.

## Root cause

- \`ai.claude\` in the headless profile had \`package = null\`. That's correct on Arch (claude comes from pacman/AUR) but wrong on Ubuntu-side DGX where nothing else provides it.
- There was no \`nyx.modules.ai.codex\` module at all. The launcher references \`codex\` unconditionally.

## Fix

1. New \`home/shared/modules/ai/codex/default.nix\` — wraps \`pkgs.codex\` (nixpkgs 0.142.0, aarch64-available). Same shape as the claude module: a package option that can be null on hosts installing codex elsewhere.
2. \`home/shared/profiles/headless.nix\`: drop \`package = null\` from \`ai.claude\` so nyx installs \`pkgs.claude-code\` (aarch64 build available); enable \`ai.codex\`.

Verified: \`nix eval .#homeConfigurations.castor.activationPackage\` succeeds. Arch hosts (prometheus, L242731) are unaffected — they set \`package = null\` in their own host \`default.nix\`, not via the profile.