### PR TITLE
feat(shell/git): make github SSH URL rewrite opt-in

### DIFF
--- a/home/shared/modules/shell/git/default.nix
+++ b/home/shared/modules/shell/git/default.nix
@@ -42,6 +42,18 @@ in
       default = { };
       description = "Options related to signing commits using GnuPG.";
     };
+
+    rewriteToSSH = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Rewrite https://github.com/{uLabSystems,mwdavisii}/ URLs to
+        ssh://git@github.com/... via git's insteadOf. Convenient on
+        personal boxes with SSH keys set up; hostile on shared or
+        third-party boxes where peers may want plain HTTPS clones.
+        Set to false in profiles/headless.nix for DGX hosts.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -69,10 +81,11 @@ in
         defaultBranch = main
       [push]
         autoSetupRemote = true
+      ${if cfg.rewriteToSSH then ''
       [url "ssh://git@github.com/uLabSystems/"]
         insteadOf = https://github.com/uLabSystems/
       [url "ssh://git@github.com/mwdavisii/"]
-        insteadOf = https://github.com/mwdavisii/
+        insteadOf = https://github.com/mwdavisii/'' else ""}
       [user]
         name = "${username}"
         email = "${email}"

--- a/home/shared/profiles/headless.nix
+++ b/home/shared/profiles/headless.nix
@@ -74,7 +74,15 @@
       fastfetch.enable    = true;
       fzf.enable          = true;
       gcp.enable          = true;
-      git                 = { enable = true; signing.signByDefault = false; };
+      git                 = {
+        enable = true;
+        signing.signByDefault = false;
+        # Peers cloning nyx to their own boxes generally won't have SSH
+        # keys registered against the maintainer's GitHub — leave HTTPS
+        # URLs as HTTPS so `git clone https://...` and `git pull` work
+        # out of the box.
+        rewriteToSSH = false;
+      };
       glow.enable         = true;
       homelabTools.enable = true;
       jq.enable           = true;


### PR DESCRIPTION
Adds nyx.modules.shell.git.rewriteToSSH (default true — Arch hosts inherit the historical behavior). The git module previously wrote two unconditional url.insteadOf rules turning any
  https://github.com/{uLabSystems,mwdavisii}/...
URL into
  ssh://git@github.com/{uLabSystems,mwdavisii}/...
regardless of what URL the user typed.

That's convenient on personal boxes with SSH keys registered but hostile everywhere else — a peer running

    git clone https://github.com/mwdavisii/nyx.git

on a fresh box gets a mysterious 'Permission denied (publickey)' because the URL was silently rewritten to SSH before dialing GitHub.

Fix: gate the two [url] blocks behind cfg.rewriteToSSH, and set rewriteToSSH = false in home/shared/profiles/headless.nix so DGX hosts respect HTTPS URLs as typed.

Verified by inspecting the rendered ~/.gitconfig in the store:
  castor:     0 insteadOf entries (correct — rewrite disabled)
  prometheus: 2 insteadOf entries (correct — default behavior preserved)