### PR TITLE
fix(app/chrome): honor package=null on Arch; unblock GPU accel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782073106,
-        "narHash": "sha256-dnS5SaZlPqR1E0dPXaPc+lFkBwLUbAgbwsVMk7uA6dY=",
+        "lastModified": 1784368054,
+        "narHash": "sha256-zF1iJkBQSDWmRO4/LEeHR1SpKY0lqZaxkoQJpPS9K9U=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "6d6e2384f381def4ea4ea81543cba4bbdac72457",
+        "rev": "9b5f14d9483445e766294eb8fbe0b8f370269ed0",
         "type": "github"
       },
       "original": {
@@ -57,16 +57,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783446865,
-        "narHash": "sha256-nCrPEbQjgnSAOVWTxRXD9Yi6P3oECdtZISYcQCFI9Fs=",
+        "lastModified": 1784068757,
+        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "655769712a9a9499563d9685a8488f349354492d",
+        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.9",
+        "ref": "6.0.11",
         "repo": "brew",
         "type": "github"
       }
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783395956,
-        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783823409,
-        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
+        "lastModified": 1784546264,
+        "narHash": "sha256-jxVr5EHMYAOkFvS2k0abIvt6NqyshyWmiHHzV17sT2g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
+        "rev": "e3dea8e4792b09a6c0eb5836b0284ad05b1acba0",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783889053,
-        "narHash": "sha256-MH5aIlbn/Fi49CYRpbfs3bUL19ZVbJotxZnvK1UjMg8=",
+        "lastModified": 1784565140,
+        "narHash": "sha256-3A88OVv1Niz8wYR2svtqnTsSLmcpEpm4WSRiWlYmNfo=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "671b73472850cf52b598d08ea0a7b11dc8edef4d",
+        "rev": "baf904b678a0374739ca22424018a45999b65581",
         "type": "github"
       },
       "original": {
@@ -302,11 +302,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783892191,
-        "narHash": "sha256-hI9wCqIJXvPL2f3Ws3sUOJPeyqO0w+ktevqKDZ0OOnE=",
+        "lastModified": 1784565297,
+        "narHash": "sha256-oYPSp+x4bL9cXABLmTUaWyBz3J72IeNLGGnX67B3qMU=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "13fc27cd277dbd5274bdf77ca70c90bc8934b366",
+        "rev": "c3a3048a868d157937c22afb5bed7f71437aff55",
         "type": "github"
       },
       "original": {
@@ -390,11 +390,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1783881054,
-        "narHash": "sha256-niRSZVYUVkqmU5WI/PYq/dOpda6pm7tQxgBlDksrYdQ=",
+        "lastModified": 1784544579,
+        "narHash": "sha256-nvGvfMb/x9MfEN5M9aJYkvfUDbCcOD9XCNNF/u04RlQ=",
         "ref": "refs/heads/main",
-        "rev": "f4b9c1ab240f5c5d2b5a2e659113361e476772a5",
-        "revCount": 7570,
+        "rev": "5b260faeb9e4563b9e6bd74450a97f39a9d708e9",
+        "revCount": 7626,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -438,11 +438,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782563850,
-        "narHash": "sha256-rs/EzgrgPHbCtJjFZN4aR1HYldH/0NtGAempWVpWQTs=",
+        "lastModified": 1784196523,
+        "narHash": "sha256-ahtKMGXFJdlQNhatQm1+BBU/pGfGYnAqQt3vWvq4p8s=",
         "owner": "hyprwm",
         "repo": "hyprland-guiutils",
-        "rev": "5ba080ee036c30cb2485f2647ff8a61f7aa08178",
+        "rev": "a6ccb6cb112ed5a244c0191fb972347ecfa893e0",
         "type": "github"
       },
       "original": {
@@ -468,11 +468,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783772407,
-        "narHash": "sha256-7J/A/jatgo6jxtnALGbDgmJg1NEwDQmbojltzxtqsxE=",
+        "lastModified": 1784102347,
+        "narHash": "sha256-piRpwar7VZI3YviYo0a/UMFz9+rLesfv3nRLGKxjVGg=",
         "ref": "refs/heads/main",
-        "rev": "a2c77641bc80b749a9b02ebe6ff8dd6d727baee9",
-        "revCount": 416,
+        "rev": "7644cecdb947060682891a0db2a0cdc5c0b9e704",
+        "revCount": 417,
         "type": "git",
         "url": "https://github.com/hyprwm/hyprland-plugins"
       },
@@ -599,11 +599,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783002634,
-        "narHash": "sha256-xGqHIUK0wIZoW7SiMalwvO6uGOO/VrlQwoRobpE7dDI=",
+        "lastModified": 1784323413,
+        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "41fb809557abd29a57151b6e1aaeabd05f9437e1",
+        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
         "type": "github"
       },
       "original": {
@@ -716,11 +716,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1783875858,
-        "narHash": "sha256-+yYNOkj/bkVQmwKH0hewqwBwAEoh4Gq2BmQPIP1jNrg=",
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "60641da8324e6a1af716a0340d901ccb131c91ef",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
         "type": "github"
       },
       "original": {
@@ -801,11 +801,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783887590,
-        "narHash": "sha256-EmPz1ubb5E4jXjD2r6fZCo+8pVfSfP0DnLjNSyivoj8=",
+        "lastModified": 1784058842,
+        "narHash": "sha256-3u3tvbCIAid3Mv7RrJx13jusIEQC/HeKYhO/SUSxR3A=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "3bcfebaba738e1adbf20973996ee2cd665b9ccbe",
+        "rev": "24c8dc8e0f2170e1a377be24dfadc7d9d21dc1ad",
         "type": "github"
       },
       "original": {
@@ -864,11 +864,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -896,11 +896,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -935,11 +935,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1783869492,
-        "narHash": "sha256-47qs7UofgjxU6m7c90RycaHjvEXnVM5DeVEAtaPVPUA=",
+        "lastModified": 1784057377,
+        "narHash": "sha256-yycNej5//EsRbV10moBoh+/63vXEwZD1ZFEiRm6C9rQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4ef28e447b9003b67ff7fa9488a3be93c43312db",
+        "rev": "07180a087e4a00720dc0731cbcd8dec796974381",
         "type": "github"
       },
       "original": {
@@ -1008,11 +1008,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1783892916,
-        "narHash": "sha256-tpUssVQN9EtGbva16hu8/DpId7IF3ZHf909cthI/NDc=",
+        "lastModified": 1784566946,
+        "narHash": "sha256-84TPYM9D3g7PgyxYJ/gwl+f2Opyz9D1eVRuasvn9XcQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7174d59e3eeb55f6292ce939fefe7af891174542",
+        "rev": "bbda5d26df5eb201cddcfca4f97b812ce7c89030",
         "type": "github"
       },
       "original": {
@@ -1030,11 +1030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1784288435,
+        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
         "type": "github"
       },
       "original": {
@@ -1188,11 +1188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782644412,
-        "narHash": "sha256-/iSa/bL1QQFLv+uJ9gI0N87J8gOeZXvca7EjoPGKE6w=",
+        "lastModified": 1784371182,
+        "narHash": "sha256-S8A1lezEalltWcCp3gAic5lssS0xTSISK6fKODefhOk=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "c01c99fc278ec68c82e9865923088f043c7c1621",
+        "rev": "08d99f727944dd15e4740090305e31c5fb92a50a",
         "type": "github"
       },
       "original": {

--- a/home/shared/modules/app/chrome/default.nix
+++ b/home/shared/modules/app/chrome/default.nix
@@ -3,26 +3,28 @@
 with lib;
 let
   cfg = config.nyx.modules.app.chrome;
-  chromePath = "${pkgs.google-chrome}/bin/google-chrome-stable";
-  defaultPath = "${pkgs.qutebrowser}/bin/qutebrowser";
 in
 {
   options.nyx.modules.app.chrome = {
     enable = mkEnableOption "Google Chrome";
-    makeDefaultBrowser = mkOption{
+    package = mkOption {
+      description = ''
+        Package for Google Chrome. Set to `null` on hosts where Chrome is
+        installed outside Nix (e.g. Arch via `yay -S google-chrome`), because
+        Nix's Chrome build expects NixOS's /run/opengl-driver mechanism and
+        cannot find EGL/DRM userspace on non-NixOS systems (GPU accel breaks).
+      '';
+      type = with types; nullOr package;
+      default = pkgs.google-chrome;
+    };
+    makeDefaultBrowser = mkOption {
       type = types.bool;
       default = true;
     };
   };
 
   config = mkIf cfg.enable {
-    home.packages = with pkgs; [
-      google-chrome
-    ];
-
-   #home.sessionVariables = {
-   #   environment.sessionVariables.DEFAULT_BROWSER = if cfg.makeDefaultBrowser then "${chromePath}" else "${defaultPath}";
-   # };
+    home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
     xdg.mimeApps = {
       enable = cfg.makeDefaultBrowser;

--- a/home/shared/modules/app/chromium/default.nix
+++ b/home/shared/modules/app/chromium/default.nix
@@ -4,14 +4,21 @@ with lib;
 let cfg = config.nyx.modules.app.chromium;
 in
 {
-  options.nyx.modules.app.chromium = { 
-    enable = mkEnableOption "Chromium app"; 
+  options.nyx.modules.app.chromium = {
+    enable = mkEnableOption "Chromium app";
+    package = mkOption {
+      description = ''
+        Package for Chromium. Set to `null` on hosts where Chromium is
+        installed outside Nix (e.g. Arch via `pacman -S chromium`), because
+        Nix's Chromium build expects NixOS's /run/opengl-driver mechanism and
+        cannot find EGL/DRM userspace on non-NixOS systems (GPU accel breaks).
+      '';
+      type = with types; nullOr package;
+      default = pkgs.chromium;
+    };
   };
 
   config = mkIf cfg.enable {
-  home.packages = with pkgs;    
-      [
-        chromium
-      ];
+    home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
   };
 }

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -123,6 +123,7 @@ info "Installing core desktop packages..."
 sudo pacman -S --needed --noconfirm \
   \
   foot kitty alacritty \
+  chromium \
   linux-headers \
   dkms \
   v4l2loopback-dkms \
@@ -340,6 +341,7 @@ _PKGCFG=/usr/lib/pkgconfig:/usr/share/pkgconfig
 PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm \
   quickshell-git \
   app2unit \
+  google-chrome \
   claude-code \
   claude-desktop-bin \
   ttf-material-symbols-variable \

--- a/system/arch/hosts/L242731/default.nix
+++ b/system/arch/hosts/L242731/default.nix
@@ -57,9 +57,13 @@
         enable = true;
         package = null;
       };
-      chromium.enable = true;
+      chromium = {
+        enable = true;
+        package = null; # installed via pacman (extra/chromium) — Nix build has no GPU accel on Arch
+      };
       chrome = {
         enable = true;
+        package = null; # installed via pacman (AUR/google-chrome) — Nix build has no GPU accel on Arch
         makeDefaultBrowser = true;
       };
       kitty = {

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -68,9 +68,13 @@
         enable = true;
         package = null;
       };
-      chromium.enable = true;
+      chromium = {
+        enable = true;
+        package = null; # installed via pacman (extra/chromium) — Nix build has no GPU accel on Arch
+      };
       chrome = {
         enable = true;
+        package = null; # installed via pacman (AUR/google-chrome) — Nix build has no GPU accel on Arch
         makeDefaultBrowser = true;
       };
       kitty = {


### PR DESCRIPTION
## Problem

Chrome and Chromium installed from nixpkgs have no GPU acceleration on Arch:

```
Failed to find drm render node path
eglInitialize OpenGL failed with error EGL_NOT_INITIALIZED
GPU process was unable to boot: GPU access is disabled due to frequent crashes
```

Nix's Chrome build expects NixOS's `/run/opengl-driver` mechanism to find EGL/libGL/DRM userspace. That path doesn't exist on Arch, so the GPU process can't boot — WebGL, WebGPU, Vulkan, HW video decode, and even 2D canvas all fall back to software (or nothing). Meanwhile `glxinfo`/`vulkaninfo` report the system GPU works fine — this is a Nix packaging / non-NixOS gap, not a hardware issue.

Every other GUI app in `home/shared/modules/app/` already solves this with the `package = null;` convention (kitty, discord, obsidian, alacritty, obs, wezterm, signal, sdrpp, cava, ytmPlayer, claude, scrcpy). Chrome and Chromium had missed it.

## Fix

- `home/shared/modules/app/chrome/default.nix` — add nullable `package` option (default `pkgs.google-chrome`), gate `home.packages` on `cfg.package != null`. Drop unused let-bindings and commented block.
- `home/shared/modules/app/chromium/default.nix` — same (default `pkgs.chromium`).
- `system/arch/hosts/prometheus/default.nix` and `system/arch/hosts/L242731/default.nix` — set both `chrome.package = null;` and `chromium.package = null;` so pacman owns the binary.
- `setup/arch/02-install-packages.sh` — install `chromium` (pacman core desktop block) and `google-chrome` (AUR block) so a fresh Arch host picks up both browsers automatically.

The AUR google-chrome ships `/usr/bin/google-chrome-stable` (not bare `google-chrome`), but `google-chrome.desktop` still ships so mimeApps / xdg-open / launcher entries continue to work unchanged.

## Not in this change

Chrome 150 on Wayland+AMD also needs a small runtime tuning file (`~/.config/chrome-flags.conf`) to disable its Vulkan-Skia compositor — `--ozone-platform=wayland` is incompatible with Vulkan and Chrome itself logs the message. Without that, YouTube plays as a white rectangle. That fix is host-local for now; if a second Arch host needs it we can add a `flags` option to the chrome module.

## Verification

On `prometheus` (Navi21 / RX 6900 XT), `chrome://gpu/` now reports:

```
Canvas: Hardware accelerated
Compositing: Hardware accelerated
Rasterization: Hardware accelerated
OpenGL: Enabled
Video Decode: Hardware accelerated
WebGL: Hardware accelerated
WebGPU: Hardware accelerated
WebGPU interop: Hardware accelerated
Vulkan: Enabled
```

(`Video Encode: Software only` is Chrome's Linux default — not a regression.)

## Also

Refreshes `flake.lock` with the latest input revisions from a routine `nix flake update` that was already in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)