### PR TITLE
fix(setup/arch): install slack-desktop via AUR

### DIFF
--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -353,6 +353,7 @@ PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm \
   sublime-text-4 \
   discord_arch_electron \
   signal-desktop \
+  slack-desktop \
   stockfish \
   lc0 \
   wezterm-git \


### PR DESCRIPTION
Required because nyx.modules.app.slack uses package = null on Arch hosts, so the system package must come from the bootstrap script.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)