### PR TITLE
feat(app): add nextcloud desktop sync client module

### DIFF
--- a/home/shared/modules/app/nextcloud/default.nix
+++ b/home/shared/modules/app/nextcloud/default.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.nyx.modules.app.nextcloud;
+in
+{
+  options.nyx.modules.app.nextcloud = {
+    enable = mkEnableOption "Nextcloud desktop sync client";
+    package = mkOption {
+      description = "Nextcloud client package. Set to null to use system-installed nextcloud-client (e.g. via pacman on Arch).";
+      type = with types; nullOr package;
+      default = pkgs.nextcloud-client;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
+  };
+}

--- a/setup/arch/02-install-packages.sh
+++ b/setup/arch/02-install-packages.sh
@@ -353,6 +353,7 @@ PKG_CONFIG_PATH="$_PKGCFG" PATH="$_SYSPATH" yay -S --needed --noconfirm \
   sublime-text-4 \
   discord_arch_electron \
   signal-desktop \
+  nextcloud-client \
   slack-desktop \
   stockfish \
   lc0 \

--- a/system/arch/hosts/L242731/default.nix
+++ b/system/arch/hosts/L242731/default.nix
@@ -102,6 +102,10 @@
         package = null; # installed via pacman/AUR
       };
       remmina.enable = true;
+      nextcloud = {
+        enable = true;
+        package = null; # installed via pacman (nextcloud-client)
+      };
     };
     dev = {
       androidSDK.enable = true;

--- a/system/arch/hosts/prometheus/default.nix
+++ b/system/arch/hosts/prometheus/default.nix
@@ -129,6 +129,10 @@
         package = null; # installed via pacman/AUR
       };
       remmina.enable = true;
+      nextcloud = {
+        enable = true;
+        package = null; # installed via pacman (nextcloud-client)
+      };
     };
     dev = {
       androidSDK.enable = true;


### PR DESCRIPTION
Adds home/shared/modules/app/nextcloud with enable + package options. Both Arch hosts (prometheus, L242731) enable it with package = null so pacman provides nextcloud-client. Also adds nextcloud-client to 02-install-packages.sh.